### PR TITLE
Added reset/load/save settings

### DIFF
--- a/calc.css
+++ b/calc.css
@@ -47,6 +47,7 @@ button.ui {
     background: linear-gradient(to bottom, var(--light), var(--medium));
     border: 2px outset var(--light);
     border-radius: 0.4em;
+    cursor: pointer;
 }
 button.ui:active {
     border-style: inset;
@@ -57,6 +58,11 @@ button.ui:focus {
 }
 button#debug_button {
     float: right;
+}
+#settings_tab button {
+    margin-top: 1em;
+    margin-left: 0.5em
+    line-height: 2em;
 }
 img.icon {
     background-repeat: no-repeat;

--- a/calc.html
+++ b/calc.html
@@ -158,6 +158,15 @@ limitations under the License.-->
         <label for="rational_format">Rationals</label></td>
         </tr>
         </table>
+        <button id="settings_reset" class="ui" onclick="resetSettings()">
+            Reset to default
+        </button>
+        <button id="settings_load" class="ui" onclick="loadSettingsLocalStorage()">
+            Load settings
+        </button>
+        <button id="settings_save" class="ui" onclick="saveSettingsLocalStorage()">
+            Save settings
+        </button>
     </div>
 
     <div id="about_tab" class="tab">

--- a/events.js
+++ b/events.js
@@ -46,6 +46,36 @@ function RateHandler(target) {
 
 // settings events
 
+function resetSettings() {
+    var settings = JSON.parse(JSON.stringify(DEFAULT_SETTINGS)) // make copy
+    delete settings.items
+    delete settings.tab
+    if (settings.data != currentMod()) {
+        document.getElementById("data_set").value = settings.data
+        changeMod()
+    }
+    renderSettings(settings)
+    itemUpdate()
+}
+
+function loadSettingsLocalStorage() {
+    var settings = JSON.parse(localStorage.getItem("settings"))
+    if (settings.data != currentMod()) {
+        document.getElementById("data_set").value = settings.data
+        changeMod()
+    }
+    renderSettings(settings)
+    itemUpdate()
+}
+
+function saveSettingsLocalStorage() {
+    var settings = loadFullSettings(window.location.hash)
+    delete settings.items
+    delete settings.tab
+    localStorage.setItem("settings", JSON.stringify(settings))
+    document.getElementById("settings_load").style.display = ""
+}
+
 // Obtains current data set from UI element, and resets the world with the new
 // data.
 function changeMod() {
@@ -357,4 +387,3 @@ function toggleVisible(targetID) {
         target.style.display = "none"
     }
 }
-

--- a/fragment.js
+++ b/fragment.js
@@ -132,5 +132,35 @@ function loadSettings(fragment) {
         var unzip = pako.inflateRaw(window.atob(settings.zip), {to: "string"})
         return loadSettings("#" + unzip)
     }
+
+    var defaults = JSON.parse(JSON.stringify(DEFAULT_SETTINGS)) // make copy
+    delete defaults.items
+    delete defaults.tab
+    for (var name in defaults) {
+        if (settings[name] && settings[name] != defaults[name]) {
+            var customisedSettings = true;
+        }
+    }
+    if (!customisedSettings && localStorageEnabled) {
+        var userDefaults = JSON.parse(localStorage.getItem("settings"))
+        for (var name in userDefaults) {
+            settings[name] = userDefaults[name]
+        }
+        if (userDefaults.data != currentMod()) {
+            document.getElementById("data_set").value = settings.data
+            changeMod()
+        }
+    }
+
+    return settings
+}
+
+function loadFullSettings(fragment) {
+    var settings = loadSettings(fragment)
+    for (var name in DEFAULT_SETTINGS) {
+        if (!(name in settings)) {
+            settings[name] = DEFAULT_SETTINGS[name]
+        }
+    }
     return settings
 }

--- a/init.js
+++ b/init.js
@@ -20,6 +20,19 @@ var itemGroups
 
 var initDone = false
 
+// check if localStorage is usable
+var localStorageEnabled
+function checkLocalStorageEnabled() {
+    var test = "test";
+    try {
+        localStorage.setItem(test, test);
+        localStorage.removeItem(test);
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
 // Set the page back to a state immediately following initial setup, but before
 // the dataset is loaded for the first time.
 //
@@ -166,6 +179,17 @@ function loadData(modName, settings) {
 }
 
 function init() {
+    localStorageEnabled = checkLocalStorageEnabled()
+    // hide reset/load/save settings if localStorage is disabled
+    if (!localStorageEnabled) {
+        document.getElementById("settings_load").style.display = "none"
+        document.getElementById("settings_save").style.display = "none"
+    }
+    // if there is no setting saved then hide the "load" button
+    else if (!localStorage.getItem("settings")) {
+        document.getElementById("settings_load").style.display = "none"
+    }
+
     var settings = loadSettings(window.location.hash)
     renderDataSetOptions(settings)
     if ("tab" in settings) {

--- a/settings.js
+++ b/settings.js
@@ -226,6 +226,8 @@ function setMinPipe(lengthString) {
 }
 
 // mining productivity bonus
+var DEFAULT_MINING_PROD = 0
+
 function renderMiningProd(settings) {
     if ("mprod" in settings) {
         var mprod = document.getElementById("mprod")
@@ -341,4 +343,21 @@ function renderSettings(settings) {
     renderDefaultModule(settings)
     renderDefaultBeacon(settings)
     renderValueFormat(settings)
+}
+
+// this is easy to loop through to get missing settings
+var DEFAULT_SETTINGS = {
+    "items": DEFAULT_ITEM + ":f:1",
+    "tab": DEFAULT_TAB,
+    "data": DEFAULT_MODIFICATION,
+    "rate": DEFAULT_RATE,
+    "rp": DEFAULT_RATE_PRECISION,
+    "cp": DEFAULT_COUNT_PRECISION,
+    "min": DEFAULT_MINIMUM,
+    // DEFAULT_FURNACE isn't set till later :( hacky
+    "furnace": "electric-furnace",
+    "belt": DEFAULT_BELT,
+    "pipe": DEFAULT_PIPE.toString(),
+    "mprod": DEFAULT_MINING_PROD,
+    "vf": DEFAULT_FORMAT[0]
 }


### PR DESCRIPTION
Added reset/load/save settings

Settings page:
- Added reset settings button (resets to default)
- Added save/load custom settings button (stored in localStorage.settings)
Save/load buttons are hidden when localStorage is no accessible
Load button is hidden when there is nothing to load

loadSettings now loads saved custom settings by default if all settings are default (if the user likes the default settings, then they can save default settings as custom settings so they aren't forced off the default settings or they can simply not save the custom settings)