### PR TITLE
Partial update to 0.16.1

### DIFF
--- a/data/vanilla-0.16.1.json
+++ b/data/vanilla-0.16.1.json
@@ -1,0 +1,8775 @@
+{
+    "accumulator": {
+        "accumulator": {
+            "energy_source": {
+                "buffer_capacity": "5MJ",
+                "input_flow_limit": "300kW",
+                "output_flow_limit": "300kW",
+                "type": "electric",
+                "usage_priority": "terciary"
+            },
+            "icon_col": 0,
+            "icon_row": 0,
+            "name": "accumulator"
+        }
+    },
+    "assembling-machine": {
+        "assembling-machine-1": {
+            "crafting_categories": [
+                "crafting"
+            ],
+            "crafting_speed": 0.5,
+            "energy_usage": 90000.0,
+            "icon_col": 4,
+            "icon_row": 0,
+            "ingredient_count": 2,
+            "module_slots": 0,
+            "name": "assembling-machine-1"
+        },
+        "assembling-machine-2": {
+            "allowed_effects": [
+                "consumption",
+                "speed",
+                "productivity",
+                "pollution"
+            ],
+            "crafting_categories": [
+                "crafting",
+                "advanced-crafting",
+                "crafting-with-fluid"
+            ],
+            "crafting_speed": 0.75,
+            "energy_usage": 150000.0,
+            "icon_col": 5,
+            "icon_row": 0,
+            "ingredient_count": 4,
+            "module_slots": 2,
+            "name": "assembling-machine-2"
+        },
+        "assembling-machine-3": {
+            "allowed_effects": [
+                "consumption",
+                "speed",
+                "productivity",
+                "pollution"
+            ],
+            "crafting_categories": [
+                "crafting",
+                "advanced-crafting",
+                "crafting-with-fluid"
+            ],
+            "crafting_speed": 1.25,
+            "energy_usage": 210000.0,
+            "icon_col": 6,
+            "icon_row": 0,
+            "ingredient_count": 6,
+            "module_slots": 4,
+            "name": "assembling-machine-3"
+        },
+        "centrifuge": {
+            "allowed_effects": [
+                "consumption",
+                "speed",
+                "productivity",
+                "pollution"
+            ],
+            "crafting_categories": [
+                "centrifuging"
+            ],
+            "crafting_speed": 0.75,
+            "energy_usage": 350000.0,
+            "icon_col": 9,
+            "icon_row": 1,
+            "ingredient_count": 2,
+            "module_slots": 2,
+            "name": "centrifuge"
+        },
+        "chemical-plant": {
+            "allowed_effects": [
+                "consumption",
+                "speed",
+                "productivity",
+                "pollution"
+            ],
+            "crafting_categories": [
+                "chemistry"
+            ],
+            "crafting_speed": 1.25,
+            "energy_usage": 210000.0,
+            "icon_col": 10,
+            "icon_row": 1,
+            "ingredient_count": 4,
+            "module_slots": 3,
+            "name": "chemical-plant"
+        },
+        "oil-refinery": {
+            "allowed_effects": [
+                "consumption",
+                "speed",
+                "productivity",
+                "pollution"
+            ],
+            "crafting_categories": [
+                "oil-processing"
+            ],
+            "crafting_speed": 1,
+            "energy_usage": 420000.0,
+            "icon_col": 10,
+            "icon_row": 8,
+            "ingredient_count": 4,
+            "module_slots": 3,
+            "name": "oil-refinery"
+        }
+    },
+    "boiler": {
+        "boiler": {
+            "energy_consumption": "1.8MW",
+            "energy_source": {
+                "effectivity": 0.5,
+                "emissions": 0.015384615384615,
+                "fuel_category": "chemical",
+                "fuel_inventory_size": 1,
+                "smoke": [
+                    {
+                        "east_position": [
+                            0.625,
+                            -2.1875
+                        ],
+                        "frequency": 15,
+                        "name": "smoke",
+                        "north_position": [
+                            -1.1875,
+                            -1.484375
+                        ],
+                        "south_position": [
+                            1.203125,
+                            -1
+                        ],
+                        "starting_frame_deviation": 60,
+                        "starting_vertical_speed": 0,
+                        "west_position": [
+                            -0.59375,
+                            -0.265625
+                        ]
+                    }
+                ],
+                "type": "burner"
+            },
+            "icon_col": 3,
+            "icon_row": 1,
+            "name": "boiler"
+        },
+        "heat-exchanger": {
+            "energy_consumption": "10MW",
+            "energy_source": {
+                "connections": [
+                    {
+                        "direction": 4,
+                        "position": [
+                            0,
+                            0.5
+                        ]
+                    }
+                ],
+                "max_temperature": 1000,
+                "max_transfer": "2GW",
+                "pipe_covers": {
+                    "east": {
+                        "filename": "__base__/graphics/entity/heat-exchanger/heatex-endings.png",
+                        "frame_count": 1,
+                        "height": 32,
+                        "hr_version": {
+                            "filename": "__base__/graphics/entity/heat-exchanger/hr-heatex-endings.png",
+                            "frame_count": 1,
+                            "height": 64,
+                            "line_length": 4,
+                            "priority": "high",
+                            "scale": 0.5,
+                            "width": 64,
+                            "x": 64
+                        },
+                        "line_length": 4,
+                        "priority": "high",
+                        "scale": 1,
+                        "width": 32,
+                        "x": 32
+                    },
+                    "north": {
+                        "filename": "__base__/graphics/entity/heat-exchanger/heatex-endings.png",
+                        "frame_count": 1,
+                        "height": 32,
+                        "hr_version": {
+                            "filename": "__base__/graphics/entity/heat-exchanger/hr-heatex-endings.png",
+                            "frame_count": 1,
+                            "height": 64,
+                            "line_length": 4,
+                            "priority": "high",
+                            "scale": 0.5,
+                            "width": 64,
+                            "x": 0
+                        },
+                        "line_length": 4,
+                        "priority": "high",
+                        "scale": 1,
+                        "width": 32,
+                        "x": 0
+                    },
+                    "south": {
+                        "filename": "__base__/graphics/entity/heat-exchanger/heatex-endings.png",
+                        "frame_count": 1,
+                        "height": 32,
+                        "hr_version": {
+                            "filename": "__base__/graphics/entity/heat-exchanger/hr-heatex-endings.png",
+                            "frame_count": 1,
+                            "height": 64,
+                            "line_length": 4,
+                            "priority": "high",
+                            "scale": 0.5,
+                            "width": 64,
+                            "x": 128
+                        },
+                        "line_length": 4,
+                        "priority": "high",
+                        "scale": 1,
+                        "width": 32,
+                        "x": 64
+                    },
+                    "west": {
+                        "filename": "__base__/graphics/entity/heat-exchanger/heatex-endings.png",
+                        "frame_count": 1,
+                        "height": 32,
+                        "hr_version": {
+                            "filename": "__base__/graphics/entity/heat-exchanger/hr-heatex-endings.png",
+                            "frame_count": 1,
+                            "height": 64,
+                            "line_length": 4,
+                            "priority": "high",
+                            "scale": 0.5,
+                            "width": 64,
+                            "x": 192
+                        },
+                        "line_length": 4,
+                        "priority": "high",
+                        "scale": 1,
+                        "width": 32,
+                        "x": 96
+                    }
+                },
+                "specific_heat": "1MJ",
+                "type": "heat"
+            },
+            "icon_col": 2,
+            "icon_row": 6,
+            "name": "heat-exchanger"
+        }
+    },
+    "fluids": [
+        "crude-oil",
+        "heavy-oil",
+        "light-oil",
+        "lubricant",
+        "petroleum-gas",
+        "steam",
+        "sulfuric-acid",
+        "water"
+    ],
+    "fuel": [
+        "coal",
+        "raw-wood",
+        "rocket-fuel",
+        "small-electric-pole",
+        "solid-fuel",
+        "wood",
+        "wooden-chest"
+    ],
+    "furnace": {
+        "electric-furnace": {
+            "allowed_effects": [
+                "consumption",
+                "speed",
+                "productivity",
+                "pollution"
+            ],
+            "crafting_categories": [
+                "smelting"
+            ],
+            "crafting_speed": 2,
+            "energy_source": {
+                "emissions": 0.005,
+                "type": "electric",
+                "usage_priority": "secondary-input"
+            },
+            "energy_usage": 180000.0,
+            "icon_col": 9,
+            "icon_row": 3,
+            "module_slots": 2,
+            "name": "electric-furnace"
+        },
+        "steel-furnace": {
+            "crafting_categories": [
+                "smelting"
+            ],
+            "crafting_speed": 2,
+            "energy_source": {
+                "effectivity": 1,
+                "emissions": 0.02,
+                "fuel_category": "chemical",
+                "fuel_inventory_size": 1,
+                "smoke": [
+                    {
+                        "frequency": 10,
+                        "name": "smoke",
+                        "position": [
+                            0.7,
+                            -1.2
+                        ],
+                        "starting_frame_deviation": 60,
+                        "starting_vertical_speed": 0.08
+                    }
+                ],
+                "type": "burner"
+            },
+            "energy_usage": 180000.0,
+            "icon_col": 10,
+            "icon_row": 13,
+            "module_slots": 0,
+            "name": "steel-furnace"
+        },
+        "stone-furnace": {
+            "crafting_categories": [
+                "smelting"
+            ],
+            "crafting_speed": 1,
+            "energy_source": {
+                "effectivity": 1,
+                "emissions": 0.01,
+                "fuel_category": "chemical",
+                "fuel_inventory_size": 1,
+                "smoke": [
+                    {
+                        "deviation": [
+                            0.1,
+                            0.1
+                        ],
+                        "frequency": 5,
+                        "name": "smoke",
+                        "position": [
+                            0,
+                            -0.8
+                        ],
+                        "starting_frame_deviation": 60,
+                        "starting_vertical_speed": 0.08
+                    }
+                ],
+                "type": "burner"
+            },
+            "energy_usage": 180000.0,
+            "icon_col": 0,
+            "icon_row": 14,
+            "module_slots": 0,
+            "name": "stone-furnace"
+        }
+    },
+    "generator": {
+        "steam-engine": {
+            "effectivity": 1,
+            "fluid_usage_per_tick": 0.5,
+            "icon_col": 6,
+            "icon_row": 13,
+            "name": "steam-engine"
+        },
+        "steam-turbine": {
+            "effectivity": 1,
+            "fluid_usage_per_tick": 1,
+            "icon_col": 7,
+            "icon_row": 13,
+            "name": "steam-turbine"
+        }
+    },
+    "groups": {
+        "combat": {
+            "order": "d",
+            "subgroups": {
+                "ammo": "b",
+                "armor": "d",
+                "capsule": "c",
+                "defensive-structure": "f",
+                "equipment": "e",
+                "gun": "a"
+            }
+        },
+        "enemies": {
+            "order": "aa",
+            "subgroups": {
+                "enemies": "a"
+            }
+        },
+        "environment": {
+            "order": "a",
+            "subgroups": {
+                "corpses": "c",
+                "creatures": "a",
+                "grass": "b",
+                "remnants": "d",
+                "trees": "aa",
+                "wrecks": "e"
+            }
+        },
+        "fluids": {
+            "order": "e",
+            "subgroups": {
+                "fluid": "a"
+            }
+        },
+        "intermediate-products": {
+            "order": "c",
+            "subgroups": {
+                "empty-barrel": "e",
+                "fill-barrel": "d",
+                "fluid-recipes": "a",
+                "intermediate-product": "f",
+                "raw-material": "c",
+                "raw-resource": "b",
+                "science-pack": "g"
+            }
+        },
+        "logistics": {
+            "order": "aaa",
+            "subgroups": {
+                "belt": "b",
+                "circuit-network": "g",
+                "energy-pipe-distribution": "d",
+                "inserter": "c",
+                "logistic-network": "f",
+                "storage": "a",
+                "terrain": "h",
+                "transport": "e"
+            }
+        },
+        "other": {
+            "order": "z",
+            "subgroups": {
+                "other": "z"
+            }
+        },
+        "production": {
+            "order": "b",
+            "subgroups": {
+                "energy": "b",
+                "extraction-machine": "c",
+                "module": "f",
+                "production-machine": "e",
+                "smelting-machine": "d",
+                "tool": "a"
+            }
+        },
+        "signals": {
+            "order": "f",
+            "subgroups": {
+                "virtual-signal": "e",
+                "virtual-signal-color": "d",
+                "virtual-signal-letter": "c",
+                "virtual-signal-number": "b",
+                "virtual-signal-special": "a"
+            }
+        }
+    },
+    "items": {
+        "accumulator": {
+            "group": "production",
+            "icon_col": 0,
+            "icon_row": 0,
+            "name": "accumulator",
+            "order": "e[accumulator]-a[accumulator]",
+            "subgroup": "energy",
+            "type": "item"
+        },
+        "advanced-circuit": {
+            "group": "intermediate-products",
+            "icon_col": 1,
+            "icon_row": 0,
+            "name": "advanced-circuit",
+            "order": "f[advanced-circuit]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "arithmetic-combinator": {
+            "group": "logistics",
+            "icon_col": 3,
+            "icon_row": 0,
+            "name": "arithmetic-combinator",
+            "order": "c[combinators]-a[arithmetic-combinator]",
+            "subgroup": "circuit-network",
+            "type": "item"
+        },
+        "assembling-machine-1": {
+            "group": "production",
+            "icon_col": 4,
+            "icon_row": 0,
+            "name": "assembling-machine-1",
+            "order": "a[assembling-machine-1]",
+            "subgroup": "production-machine",
+            "type": "item"
+        },
+        "assembling-machine-2": {
+            "group": "production",
+            "icon_col": 5,
+            "icon_row": 0,
+            "name": "assembling-machine-2",
+            "order": "b[assembling-machine-2]",
+            "subgroup": "production-machine",
+            "type": "item"
+        },
+        "assembling-machine-3": {
+            "group": "production",
+            "icon_col": 6,
+            "icon_row": 0,
+            "name": "assembling-machine-3",
+            "order": "c[assembling-machine-3]",
+            "subgroup": "production-machine",
+            "type": "item"
+        },
+        "atomic-bomb": {
+            "group": "combat",
+            "icon_col": 7,
+            "icon_row": 0,
+            "name": "atomic-bomb",
+            "order": "d[rocket-launcher]-c[atomic-bomb]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "battery": {
+            "group": "intermediate-products",
+            "icon_col": 9,
+            "icon_row": 0,
+            "name": "battery",
+            "order": "j[battery]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "battery-equipment": {
+            "group": "combat",
+            "icon_col": 10,
+            "icon_row": 0,
+            "name": "battery-equipment",
+            "order": "c[battery]-a[battery-equipment]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "battery-mk2-equipment": {
+            "group": "combat",
+            "icon_col": 11,
+            "icon_row": 0,
+            "name": "battery-mk2-equipment",
+            "order": "c[battery]-b[battery-equipment-mk2]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "beacon": {
+            "group": "production",
+            "icon_col": 12,
+            "icon_row": 0,
+            "name": "beacon",
+            "order": "a[beacon]",
+            "subgroup": "module",
+            "type": "item"
+        },
+        "belt-immunity-equipment": {
+            "group": "combat",
+            "icon_col": 13,
+            "icon_row": 0,
+            "name": "belt-immunity-equipment",
+            "order": "a[belt-immunity]-a[belt-immunity]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "big-electric-pole": {
+            "group": "logistics",
+            "icon_col": 0,
+            "icon_row": 1,
+            "name": "big-electric-pole",
+            "order": "a[energy]-c[big-electric-pole]",
+            "subgroup": "energy-pipe-distribution",
+            "type": "item"
+        },
+        "blueprint": {
+            "group": "production",
+            "icon_col": 1,
+            "icon_row": 1,
+            "name": "blueprint",
+            "order": "c[automated-construction]-a[blueprint]",
+            "subgroup": "tool",
+            "type": "blueprint"
+        },
+        "blueprint-book": {
+            "group": "production",
+            "icon_col": 2,
+            "icon_row": 1,
+            "name": "blueprint-book",
+            "order": "c[automated-construction]-c[blueprint-book]",
+            "subgroup": "tool",
+            "type": "blueprint-book"
+        },
+        "boiler": {
+            "group": "production",
+            "icon_col": 3,
+            "icon_row": 1,
+            "name": "boiler",
+            "order": "b[steam-power]-a[boiler]",
+            "subgroup": "energy",
+            "type": "item"
+        },
+        "burner-inserter": {
+            "group": "logistics",
+            "icon_col": 4,
+            "icon_row": 1,
+            "name": "burner-inserter",
+            "order": "a[burner-inserter]",
+            "subgroup": "inserter",
+            "type": "item"
+        },
+        "burner-mining-drill": {
+            "group": "production",
+            "icon_col": 5,
+            "icon_row": 1,
+            "name": "burner-mining-drill",
+            "order": "a[items]-a[burner-mining-drill]",
+            "subgroup": "extraction-machine",
+            "type": "item"
+        },
+        "cannon-shell": {
+            "group": "combat",
+            "icon_col": 6,
+            "icon_row": 1,
+            "name": "cannon-shell",
+            "order": "d[cannon-shell]-a[basic]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "car": {
+            "group": "logistics",
+            "icon_col": 7,
+            "icon_row": 1,
+            "name": "car",
+            "order": "b[personal-transport]-a[car]",
+            "subgroup": "transport",
+            "type": "item-with-entity-data"
+        },
+        "cargo-wagon": {
+            "group": "logistics",
+            "icon_col": 8,
+            "icon_row": 1,
+            "name": "cargo-wagon",
+            "order": "a[train-system]-g[cargo-wagon]",
+            "subgroup": "transport",
+            "type": "item-with-entity-data"
+        },
+        "centrifuge": {
+            "group": "production",
+            "icon_col": 9,
+            "icon_row": 1,
+            "name": "centrifuge",
+            "order": "g[centrifuge]",
+            "subgroup": "production-machine",
+            "type": "item"
+        },
+        "chemical-plant": {
+            "group": "production",
+            "icon_col": 10,
+            "icon_row": 1,
+            "name": "chemical-plant",
+            "order": "e[chemical-plant]",
+            "subgroup": "production-machine",
+            "type": "item"
+        },
+        "cluster-grenade": {
+            "group": "combat",
+            "icon_col": 11,
+            "icon_row": 1,
+            "name": "cluster-grenade",
+            "order": "a[grenade]-b[cluster]",
+            "subgroup": "capsule",
+            "type": "capsule"
+        },
+        "coal": {
+            "fuel_category": "chemical",
+            "fuel_value": 8000000.0,
+            "group": "intermediate-products",
+            "icon_col": 12,
+            "icon_row": 1,
+            "name": "coal",
+            "order": "b[coal]",
+            "subgroup": "raw-resource",
+            "type": "item"
+        },
+        "coin": {
+            "group": "intermediate-products",
+            "icon_col": 0,
+            "icon_row": 2,
+            "name": "coin",
+            "order": "y",
+            "subgroup": "science-pack",
+            "type": "item"
+        },
+        "combat-shotgun": {
+            "group": "combat",
+            "icon_col": 1,
+            "icon_row": 2,
+            "name": "combat-shotgun",
+            "order": "b[shotgun]-a[combat]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "computer": {
+            "group": "combat",
+            "icon_col": 2,
+            "icon_row": 2,
+            "name": "computer",
+            "order": "g[computer]",
+            "subgroup": "defensive-structure",
+            "type": "item"
+        },
+        "concrete": {
+            "group": "logistics",
+            "icon_col": 3,
+            "icon_row": 2,
+            "name": "concrete",
+            "order": "b[concrete]-a[plain]",
+            "subgroup": "terrain",
+            "type": "item"
+        },
+        "constant-combinator": {
+            "group": "logistics",
+            "icon_col": 4,
+            "icon_row": 2,
+            "name": "constant-combinator",
+            "order": "c[combinators]-c[constant-combinator]",
+            "subgroup": "circuit-network",
+            "type": "item"
+        },
+        "construction-robot": {
+            "group": "logistics",
+            "icon_col": 5,
+            "icon_row": 2,
+            "name": "construction-robot",
+            "order": "a[robot]-b[construction-robot]",
+            "subgroup": "logistic-network",
+            "type": "item"
+        },
+        "copper-cable": {
+            "group": "intermediate-products",
+            "icon_col": 6,
+            "icon_row": 2,
+            "name": "copper-cable",
+            "order": "a[copper-cable]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "copper-ore": {
+            "group": "intermediate-products",
+            "icon_col": 7,
+            "icon_row": 2,
+            "name": "copper-ore",
+            "order": "f[copper-ore]",
+            "subgroup": "raw-resource",
+            "type": "item"
+        },
+        "copper-plate": {
+            "group": "intermediate-products",
+            "icon_col": 8,
+            "icon_row": 2,
+            "name": "copper-plate",
+            "order": "c[copper-plate]",
+            "subgroup": "raw-material",
+            "type": "item"
+        },
+        "crude-oil": {
+            "group": "other",
+            "icon_col": 10,
+            "icon_row": 2,
+            "name": "crude-oil",
+            "order": "a[fluid]-b[crude-oil]",
+            "subgroup": "other",
+            "type": "fluid"
+        },
+        "decider-combinator": {
+            "group": "logistics",
+            "icon_col": 11,
+            "icon_row": 2,
+            "name": "decider-combinator",
+            "order": "c[combinators]-b[decider-combinator]",
+            "subgroup": "circuit-network",
+            "type": "item"
+        },
+        "deconstruction-planner": {
+            "group": "production",
+            "icon_col": 12,
+            "icon_row": 2,
+            "name": "deconstruction-planner",
+            "order": "c[automated-construction]-b[deconstruction-planner]",
+            "subgroup": "tool",
+            "type": "deconstruction-item"
+        },
+        "defender-capsule": {
+            "group": "combat",
+            "icon_col": 13,
+            "icon_row": 2,
+            "name": "defender-capsule",
+            "order": "d[defender-capsule]",
+            "subgroup": "capsule",
+            "type": "capsule"
+        },
+        "destroyer-capsule": {
+            "group": "combat",
+            "icon_col": 0,
+            "icon_row": 3,
+            "name": "destroyer-capsule",
+            "order": "f[destroyer-capsule]",
+            "subgroup": "capsule",
+            "type": "capsule"
+        },
+        "discharge-defense-equipment": {
+            "group": "combat",
+            "icon_col": 2,
+            "icon_row": 3,
+            "name": "discharge-defense-equipment",
+            "order": "d[active-defense]-b[discharge-defense-equipment]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "discharge-defense-remote": {
+            "group": "combat",
+            "icon_col": 3,
+            "icon_row": 3,
+            "name": "discharge-defense-remote",
+            "order": "z",
+            "subgroup": "capsule",
+            "type": "capsule"
+        },
+        "distractor-capsule": {
+            "group": "combat",
+            "icon_col": 4,
+            "icon_row": 3,
+            "name": "distractor-capsule",
+            "order": "e[defender-capsule]",
+            "subgroup": "capsule",
+            "type": "capsule"
+        },
+        "effectivity-module": {
+            "category": "effectivity",
+            "effect": {
+                "consumption": {
+                    "bonus": -0.3
+                }
+            },
+            "group": "production",
+            "icon_col": 5,
+            "icon_row": 3,
+            "name": "effectivity-module",
+            "order": "c[effectivity]-a[effectivity-module-1]",
+            "subgroup": "module",
+            "type": "module"
+        },
+        "effectivity-module-2": {
+            "category": "effectivity",
+            "effect": {
+                "consumption": {
+                    "bonus": -0.4
+                }
+            },
+            "group": "production",
+            "icon_col": 6,
+            "icon_row": 3,
+            "name": "effectivity-module-2",
+            "order": "c[effectivity]-b[effectivity-module-2]",
+            "subgroup": "module",
+            "type": "module"
+        },
+        "effectivity-module-3": {
+            "category": "effectivity",
+            "effect": {
+                "consumption": {
+                    "bonus": -0.5
+                }
+            },
+            "group": "production",
+            "icon_col": 7,
+            "icon_row": 3,
+            "name": "effectivity-module-3",
+            "order": "c[effectivity]-c[effectivity-module-3]",
+            "subgroup": "module",
+            "type": "module"
+        },
+        "electric-engine-unit": {
+            "group": "intermediate-products",
+            "icon_col": 8,
+            "icon_row": 3,
+            "name": "electric-engine-unit",
+            "order": "i[electric-engine-unit]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "electric-furnace": {
+            "group": "production",
+            "icon_col": 9,
+            "icon_row": 3,
+            "name": "electric-furnace",
+            "order": "c[electric-furnace]",
+            "subgroup": "smelting-machine",
+            "type": "item"
+        },
+        "electric-mining-drill": {
+            "group": "production",
+            "icon_col": 10,
+            "icon_row": 3,
+            "name": "electric-mining-drill",
+            "order": "a[items]-b[electric-mining-drill]",
+            "subgroup": "extraction-machine",
+            "type": "item"
+        },
+        "electronic-circuit": {
+            "group": "intermediate-products",
+            "icon_col": 11,
+            "icon_row": 3,
+            "name": "electronic-circuit",
+            "order": "e[electronic-circuit]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "empty-barrel": {
+            "group": "intermediate-products",
+            "icon_col": 12,
+            "icon_row": 3,
+            "name": "empty-barrel",
+            "order": "d[empty-barrel]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "energy-shield-equipment": {
+            "group": "combat",
+            "icon_col": 13,
+            "icon_row": 3,
+            "name": "energy-shield-equipment",
+            "order": "b[shield]-a[energy-shield-equipment]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "energy-shield-mk2-equipment": {
+            "group": "combat",
+            "icon_col": 0,
+            "icon_row": 4,
+            "name": "energy-shield-mk2-equipment",
+            "order": "b[shield]-b[energy-shield-equipment-mk2]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "engine-unit": {
+            "group": "intermediate-products",
+            "icon_col": 1,
+            "icon_row": 4,
+            "name": "engine-unit",
+            "order": "h[engine-unit]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "exoskeleton-equipment": {
+            "group": "combat",
+            "icon_col": 2,
+            "icon_row": 4,
+            "name": "exoskeleton-equipment",
+            "order": "e[exoskeleton]-a[exoskeleton-equipment]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "explosive-cannon-shell": {
+            "group": "combat",
+            "icon_col": 3,
+            "icon_row": 4,
+            "name": "explosive-cannon-shell",
+            "order": "d[cannon-shell]-c[explosive]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "explosive-rocket": {
+            "group": "combat",
+            "icon_col": 4,
+            "icon_row": 4,
+            "name": "explosive-rocket",
+            "order": "d[rocket-launcher]-b[explosive]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "explosive-uranium-cannon-shell": {
+            "group": "combat",
+            "icon_col": 5,
+            "icon_row": 4,
+            "name": "explosive-uranium-cannon-shell",
+            "order": "d[explosive-cannon-shell]-c[uranium]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "explosives": {
+            "group": "intermediate-products",
+            "icon_col": 6,
+            "icon_row": 4,
+            "name": "explosives",
+            "order": "j[explosives]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "express-loader": {
+            "group": "logistics",
+            "icon_col": 7,
+            "icon_row": 4,
+            "name": "express-loader",
+            "order": "d[loader]-c[express-loader]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "express-splitter": {
+            "group": "logistics",
+            "icon_col": 8,
+            "icon_row": 4,
+            "name": "express-splitter",
+            "order": "c[splitter]-c[express-splitter]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "express-transport-belt": {
+            "group": "logistics",
+            "icon_col": 9,
+            "icon_row": 4,
+            "name": "express-transport-belt",
+            "order": "a[transport-belt]-c[express-transport-belt]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "express-underground-belt": {
+            "group": "logistics",
+            "icon_col": 10,
+            "icon_row": 4,
+            "name": "express-underground-belt",
+            "order": "b[underground-belt]-c[express-underground-belt]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "fast-inserter": {
+            "group": "logistics",
+            "icon_col": 11,
+            "icon_row": 4,
+            "name": "fast-inserter",
+            "order": "d[fast-inserter]",
+            "subgroup": "inserter",
+            "type": "item"
+        },
+        "fast-loader": {
+            "group": "logistics",
+            "icon_col": 12,
+            "icon_row": 4,
+            "name": "fast-loader",
+            "order": "d[loader]-b[fast-loader]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "fast-splitter": {
+            "group": "logistics",
+            "icon_col": 13,
+            "icon_row": 4,
+            "name": "fast-splitter",
+            "order": "c[splitter]-b[fast-splitter]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "fast-transport-belt": {
+            "group": "logistics",
+            "icon_col": 0,
+            "icon_row": 5,
+            "name": "fast-transport-belt",
+            "order": "a[transport-belt]-b[fast-transport-belt]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "fast-underground-belt": {
+            "group": "logistics",
+            "icon_col": 1,
+            "icon_row": 5,
+            "name": "fast-underground-belt",
+            "order": "b[underground-belt]-b[fast-underground-belt]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "filter-inserter": {
+            "group": "logistics",
+            "icon_col": 2,
+            "icon_row": 5,
+            "name": "filter-inserter",
+            "order": "e[filter-inserter]",
+            "subgroup": "inserter",
+            "type": "item"
+        },
+        "firearm-magazine": {
+            "group": "combat",
+            "icon_col": 3,
+            "icon_row": 5,
+            "name": "firearm-magazine",
+            "order": "a[basic-clips]-a[firearm-magazine]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "flamethrower": {
+            "group": "combat",
+            "icon_col": 5,
+            "icon_row": 5,
+            "name": "flamethrower",
+            "order": "e[flamethrower]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "flamethrower-ammo": {
+            "group": "combat",
+            "icon_col": 6,
+            "icon_row": 5,
+            "name": "flamethrower-ammo",
+            "order": "e[flamethrower]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "flamethrower-turret": {
+            "group": "combat",
+            "icon_col": 7,
+            "icon_row": 5,
+            "name": "flamethrower-turret",
+            "order": "b[turret]-c[flamethrower-turret]",
+            "subgroup": "defensive-structure",
+            "type": "item"
+        },
+        "fluid-wagon": {
+            "group": "logistics",
+            "icon_col": 8,
+            "icon_row": 5,
+            "name": "fluid-wagon",
+            "order": "a[train-system]-h[fluid-wagon]",
+            "subgroup": "transport",
+            "type": "item-with-entity-data"
+        },
+        "flying-robot-frame": {
+            "group": "intermediate-products",
+            "icon_col": 9,
+            "icon_row": 5,
+            "name": "flying-robot-frame",
+            "order": "l[flying-robot-frame]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "fusion-reactor-equipment": {
+            "group": "combat",
+            "icon_col": 10,
+            "icon_row": 5,
+            "name": "fusion-reactor-equipment",
+            "order": "a[energy-source]-b[fusion-reactor]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "gate": {
+            "group": "combat",
+            "icon_col": 11,
+            "icon_row": 5,
+            "name": "gate",
+            "order": "a[wall]-b[gate]",
+            "subgroup": "defensive-structure",
+            "type": "item"
+        },
+        "green-wire": {
+            "group": "logistics",
+            "icon_col": 12,
+            "icon_row": 5,
+            "name": "green-wire",
+            "order": "b[wires]-b[green-wire]",
+            "subgroup": "circuit-network",
+            "type": "item"
+        },
+        "grenade": {
+            "group": "combat",
+            "icon_col": 13,
+            "icon_row": 5,
+            "name": "grenade",
+            "order": "a[grenade]-a[normal]",
+            "subgroup": "capsule",
+            "type": "capsule"
+        },
+        "gun-turret": {
+            "group": "combat",
+            "icon_col": 0,
+            "icon_row": 6,
+            "name": "gun-turret",
+            "order": "b[turret]-a[gun-turret]",
+            "subgroup": "defensive-structure",
+            "type": "item"
+        },
+        "hazard-concrete": {
+            "group": "logistics",
+            "icon_col": 1,
+            "icon_row": 6,
+            "name": "hazard-concrete",
+            "order": "b[concrete]-b[hazard]",
+            "subgroup": "terrain",
+            "type": "item"
+        },
+        "heat-exchanger": {
+            "group": "production",
+            "icon_col": 2,
+            "icon_row": 6,
+            "name": "heat-exchanger",
+            "order": "f[nuclear-energy]-b[heat-exchanger]",
+            "subgroup": "energy",
+            "type": "item"
+        },
+        "heat-pipe": {
+            "group": "production",
+            "icon_col": 3,
+            "icon_row": 6,
+            "name": "heat-pipe",
+            "order": "f[nuclear-energy]-c[heat-pipe]",
+            "subgroup": "energy",
+            "type": "item"
+        },
+        "heavy-armor": {
+            "group": "combat",
+            "icon_col": 4,
+            "icon_row": 6,
+            "name": "heavy-armor",
+            "order": "b[heavy-armor]",
+            "subgroup": "armor",
+            "type": "armor"
+        },
+        "heavy-oil": {
+            "group": "other",
+            "icon_col": 5,
+            "icon_row": 6,
+            "name": "heavy-oil",
+            "order": "a[fluid]-c[heavy-oil]",
+            "subgroup": "other",
+            "type": "fluid"
+        },
+        "high-tech-science-pack": {
+            "group": "intermediate-products",
+            "icon_col": 7,
+            "icon_row": 6,
+            "name": "high-tech-science-pack",
+            "order": "f[high-tech-science-pack]",
+            "subgroup": "science-pack",
+            "type": "tool"
+        },
+        "inserter": {
+            "group": "logistics",
+            "icon_col": 8,
+            "icon_row": 6,
+            "name": "inserter",
+            "order": "b[inserter]",
+            "subgroup": "inserter",
+            "type": "item"
+        },
+        "iron-axe": {
+            "group": "production",
+            "icon_col": 9,
+            "icon_row": 6,
+            "name": "iron-axe",
+            "order": "a[mining]-a[iron-axe]",
+            "subgroup": "tool",
+            "type": "mining-tool"
+        },
+        "iron-chest": {
+            "group": "logistics",
+            "icon_col": 10,
+            "icon_row": 6,
+            "name": "iron-chest",
+            "order": "a[items]-b[iron-chest]",
+            "subgroup": "storage",
+            "type": "item"
+        },
+        "iron-gear-wheel": {
+            "group": "intermediate-products",
+            "icon_col": 11,
+            "icon_row": 6,
+            "name": "iron-gear-wheel",
+            "order": "c[iron-gear-wheel]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "iron-ore": {
+            "group": "intermediate-products",
+            "icon_col": 12,
+            "icon_row": 6,
+            "name": "iron-ore",
+            "order": "e[iron-ore]",
+            "subgroup": "raw-resource",
+            "type": "item"
+        },
+        "iron-plate": {
+            "group": "intermediate-products",
+            "icon_col": 13,
+            "icon_row": 6,
+            "name": "iron-plate",
+            "order": "b[iron-plate]",
+            "subgroup": "raw-material",
+            "type": "item"
+        },
+        "iron-stick": {
+            "group": "intermediate-products",
+            "icon_col": 0,
+            "icon_row": 7,
+            "name": "iron-stick",
+            "order": "b[iron-stick]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "lab": {
+            "group": "production",
+            "icon_col": 2,
+            "icon_row": 7,
+            "name": "lab",
+            "order": "g[lab]",
+            "subgroup": "production-machine",
+            "type": "item"
+        },
+        "land-mine": {
+            "group": "combat",
+            "icon_col": 3,
+            "icon_row": 7,
+            "name": "land-mine",
+            "order": "f[land-mine]",
+            "subgroup": "gun",
+            "type": "item"
+        },
+        "landfill": {
+            "group": "logistics",
+            "icon_col": 4,
+            "icon_row": 7,
+            "name": "landfill",
+            "order": "c[landfill]-a[dirt]",
+            "subgroup": "terrain",
+            "type": "item"
+        },
+        "laser-turret": {
+            "group": "combat",
+            "icon_col": 5,
+            "icon_row": 7,
+            "name": "laser-turret",
+            "order": "b[turret]-b[laser-turret]",
+            "subgroup": "defensive-structure",
+            "type": "item"
+        },
+        "light-armor": {
+            "group": "combat",
+            "icon_col": 6,
+            "icon_row": 7,
+            "name": "light-armor",
+            "order": "a[light-armor]",
+            "subgroup": "armor",
+            "type": "armor"
+        },
+        "light-oil": {
+            "group": "other",
+            "icon_col": 7,
+            "icon_row": 7,
+            "name": "light-oil",
+            "order": "a[fluid]-d[light-oil]",
+            "subgroup": "other",
+            "type": "fluid"
+        },
+        "loader": {
+            "group": "logistics",
+            "icon_col": 9,
+            "icon_row": 7,
+            "name": "loader",
+            "order": "d[loader]-a[basic-loader]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "locomotive": {
+            "group": "logistics",
+            "icon_col": 1,
+            "icon_row": 3,
+            "name": "locomotive",
+            "order": "a[train-system]-f[diesel-locomotive]",
+            "subgroup": "transport",
+            "type": "item-with-entity-data"
+        },
+        "logistic-chest-active-provider": {
+            "group": "logistics",
+            "icon_col": 10,
+            "icon_row": 7,
+            "name": "logistic-chest-active-provider",
+            "order": "b[storage]-c[logistic-chest-active-provider]",
+            "subgroup": "logistic-network",
+            "type": "item"
+        },
+        "logistic-chest-passive-provider": {
+            "group": "logistics",
+            "icon_col": 11,
+            "icon_row": 7,
+            "name": "logistic-chest-passive-provider",
+            "order": "b[storage]-c[logistic-chest-passive-provider]",
+            "subgroup": "logistic-network",
+            "type": "item"
+        },
+        "logistic-chest-requester": {
+            "group": "logistics",
+            "icon_col": 12,
+            "icon_row": 7,
+            "name": "logistic-chest-requester",
+            "order": "b[storage]-c[logistic-chest-requester]",
+            "subgroup": "logistic-network",
+            "type": "item"
+        },
+        "logistic-chest-storage": {
+            "group": "logistics",
+            "icon_col": 13,
+            "icon_row": 7,
+            "name": "logistic-chest-storage",
+            "order": "b[storage]-c[logistic-chest-storage]",
+            "subgroup": "logistic-network",
+            "type": "item"
+        },
+        "logistic-robot": {
+            "group": "logistics",
+            "icon_col": 0,
+            "icon_row": 8,
+            "name": "logistic-robot",
+            "order": "a[robot]-a[logistic-robot]",
+            "subgroup": "logistic-network",
+            "type": "item"
+        },
+        "long-handed-inserter": {
+            "group": "logistics",
+            "icon_col": 1,
+            "icon_row": 8,
+            "name": "long-handed-inserter",
+            "order": "c[long-handed-inserter]",
+            "subgroup": "inserter",
+            "type": "item"
+        },
+        "low-density-structure": {
+            "group": "intermediate-products",
+            "icon_col": 8,
+            "icon_row": 11,
+            "name": "low-density-structure",
+            "order": "m[rocket-structure]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "lubricant": {
+            "group": "other",
+            "icon_col": 2,
+            "icon_row": 8,
+            "name": "lubricant",
+            "order": "e[lubricant]",
+            "subgroup": "other",
+            "type": "fluid"
+        },
+        "medium-electric-pole": {
+            "group": "logistics",
+            "icon_col": 3,
+            "icon_row": 8,
+            "name": "medium-electric-pole",
+            "order": "a[energy]-b[medium-electric-pole]",
+            "subgroup": "energy-pipe-distribution",
+            "type": "item"
+        },
+        "military-science-pack": {
+            "group": "intermediate-products",
+            "icon_col": 4,
+            "icon_row": 8,
+            "name": "military-science-pack",
+            "order": "d[military-science-pack]",
+            "subgroup": "science-pack",
+            "type": "tool"
+        },
+        "modular-armor": {
+            "group": "combat",
+            "icon_col": 5,
+            "icon_row": 8,
+            "name": "modular-armor",
+            "order": "c[modular-armor]",
+            "subgroup": "armor",
+            "type": "armor"
+        },
+        "night-vision-equipment": {
+            "group": "combat",
+            "icon_col": 6,
+            "icon_row": 8,
+            "name": "night-vision-equipment",
+            "order": "f[night-vision]-a[night-vision-equipment]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "nuclear-reactor": {
+            "group": "production",
+            "icon_col": 8,
+            "icon_row": 8,
+            "name": "nuclear-reactor",
+            "order": "f[nuclear-energy]-a[reactor]",
+            "subgroup": "energy",
+            "type": "item"
+        },
+        "offshore-pump": {
+            "group": "production",
+            "icon_col": 9,
+            "icon_row": 8,
+            "name": "offshore-pump",
+            "order": "b[fluids]-a[offshore-pump]",
+            "subgroup": "extraction-machine",
+            "type": "item"
+        },
+        "oil-refinery": {
+            "group": "production",
+            "icon_col": 10,
+            "icon_row": 8,
+            "name": "oil-refinery",
+            "order": "d[refinery]",
+            "subgroup": "production-machine",
+            "type": "item"
+        },
+        "personal-laser-defense-equipment": {
+            "group": "combat",
+            "icon_col": 11,
+            "icon_row": 8,
+            "name": "personal-laser-defense-equipment",
+            "order": "d[active-defense]-a[personal-laser-defense-equipment]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "personal-roboport-equipment": {
+            "group": "combat",
+            "icon_col": 12,
+            "icon_row": 8,
+            "name": "personal-roboport-equipment",
+            "order": "e[robotics]-a[personal-roboport-equipment]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "personal-roboport-mk2-equipment": {
+            "group": "combat",
+            "icon_col": 13,
+            "icon_row": 8,
+            "name": "personal-roboport-mk2-equipment",
+            "order": "e[robotics]-b[personal-roboport-mk2-equipment]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "petroleum-gas": {
+            "group": "other",
+            "icon_col": 0,
+            "icon_row": 9,
+            "name": "petroleum-gas",
+            "order": "a[fluid]-e[petroleum-gas]",
+            "subgroup": "other",
+            "type": "fluid"
+        },
+        "piercing-rounds-magazine": {
+            "group": "combat",
+            "icon_col": 1,
+            "icon_row": 9,
+            "name": "piercing-rounds-magazine",
+            "order": "a[basic-clips]-b[piercing-rounds-magazine]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "piercing-shotgun-shell": {
+            "group": "combat",
+            "icon_col": 2,
+            "icon_row": 9,
+            "name": "piercing-shotgun-shell",
+            "order": "b[shotgun]-b[piercing]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "pipe": {
+            "group": "logistics",
+            "icon_col": 3,
+            "icon_row": 9,
+            "name": "pipe",
+            "order": "a[pipe]-a[pipe]",
+            "subgroup": "energy-pipe-distribution",
+            "type": "item"
+        },
+        "pipe-to-ground": {
+            "group": "logistics",
+            "icon_col": 4,
+            "icon_row": 9,
+            "name": "pipe-to-ground",
+            "order": "a[pipe]-b[pipe-to-ground]",
+            "subgroup": "energy-pipe-distribution",
+            "type": "item"
+        },
+        "pistol": {
+            "group": "combat",
+            "icon_col": 5,
+            "icon_row": 9,
+            "name": "pistol",
+            "order": "a[basic-clips]-a[pistol]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "plastic-bar": {
+            "group": "intermediate-products",
+            "icon_col": 6,
+            "icon_row": 9,
+            "name": "plastic-bar",
+            "order": "g[plastic-bar]",
+            "subgroup": "raw-material",
+            "type": "item"
+        },
+        "player-port": {
+            "group": "combat",
+            "icon_col": 7,
+            "icon_row": 9,
+            "name": "player-port",
+            "order": "z[not-used]",
+            "subgroup": "defensive-structure",
+            "type": "item"
+        },
+        "poison-capsule": {
+            "group": "combat",
+            "icon_col": 8,
+            "icon_row": 9,
+            "name": "poison-capsule",
+            "order": "b[poison-capsule]",
+            "subgroup": "capsule",
+            "type": "capsule"
+        },
+        "power-armor": {
+            "group": "combat",
+            "icon_col": 9,
+            "icon_row": 9,
+            "name": "power-armor",
+            "order": "d[power-armor]",
+            "subgroup": "armor",
+            "type": "armor"
+        },
+        "power-armor-mk2": {
+            "group": "combat",
+            "icon_col": 10,
+            "icon_row": 9,
+            "name": "power-armor-mk2",
+            "order": "e[power-armor-mk2]",
+            "subgroup": "armor",
+            "type": "armor"
+        },
+        "power-switch": {
+            "group": "logistics",
+            "icon_col": 11,
+            "icon_row": 9,
+            "name": "power-switch",
+            "order": "d[other]-a[power-switch]",
+            "subgroup": "circuit-network",
+            "type": "item"
+        },
+        "processing-unit": {
+            "group": "intermediate-products",
+            "icon_col": 12,
+            "icon_row": 9,
+            "name": "processing-unit",
+            "order": "g[processing-unit]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "production-science-pack": {
+            "group": "intermediate-products",
+            "icon_col": 13,
+            "icon_row": 9,
+            "name": "production-science-pack",
+            "order": "e[production-science-pack]",
+            "subgroup": "science-pack",
+            "type": "tool"
+        },
+        "productivity-module": {
+            "category": "productivity",
+            "effect": {
+                "consumption": {
+                    "bonus": 0.4
+                },
+                "pollution": {
+                    "bonus": 0.05
+                },
+                "productivity": {
+                    "bonus": 0.04
+                },
+                "speed": {
+                    "bonus": -0.15
+                }
+            },
+            "group": "production",
+            "icon_col": 0,
+            "icon_row": 10,
+            "limitation": [
+                "sulfuric-acid",
+                "basic-oil-processing",
+                "advanced-oil-processing",
+                "coal-liquefaction",
+                "heavy-oil-cracking",
+                "light-oil-cracking",
+                "solid-fuel-from-light-oil",
+                "solid-fuel-from-heavy-oil",
+                "solid-fuel-from-petroleum-gas",
+                "lubricant",
+                "wood",
+                "iron-plate",
+                "copper-plate",
+                "steel-plate",
+                "stone-brick",
+                "sulfur",
+                "plastic-bar",
+                "empty-barrel",
+                "uranium-processing",
+                "copper-cable",
+                "iron-stick",
+                "iron-gear-wheel",
+                "electronic-circuit",
+                "advanced-circuit",
+                "processing-unit",
+                "engine-unit",
+                "electric-engine-unit",
+                "uranium-fuel-cell",
+                "explosives",
+                "battery",
+                "flying-robot-frame",
+                "low-density-structure",
+                "rocket-fuel",
+                "rocket-control-unit",
+                "rocket-part",
+                "science-pack-1",
+                "science-pack-2",
+                "science-pack-3",
+                "military-science-pack",
+                "production-science-pack",
+                "high-tech-science-pack"
+            ],
+            "name": "productivity-module",
+            "order": "c[productivity]-a[productivity-module-1]",
+            "subgroup": "module",
+            "type": "module"
+        },
+        "productivity-module-2": {
+            "category": "productivity",
+            "effect": {
+                "consumption": {
+                    "bonus": 0.6
+                },
+                "pollution": {
+                    "bonus": 0.075
+                },
+                "productivity": {
+                    "bonus": 0.06
+                },
+                "speed": {
+                    "bonus": -0.15
+                }
+            },
+            "group": "production",
+            "icon_col": 1,
+            "icon_row": 10,
+            "limitation": [
+                "sulfuric-acid",
+                "basic-oil-processing",
+                "advanced-oil-processing",
+                "coal-liquefaction",
+                "heavy-oil-cracking",
+                "light-oil-cracking",
+                "solid-fuel-from-light-oil",
+                "solid-fuel-from-heavy-oil",
+                "solid-fuel-from-petroleum-gas",
+                "lubricant",
+                "wood",
+                "iron-plate",
+                "copper-plate",
+                "steel-plate",
+                "stone-brick",
+                "sulfur",
+                "plastic-bar",
+                "empty-barrel",
+                "uranium-processing",
+                "copper-cable",
+                "iron-stick",
+                "iron-gear-wheel",
+                "electronic-circuit",
+                "advanced-circuit",
+                "processing-unit",
+                "engine-unit",
+                "electric-engine-unit",
+                "uranium-fuel-cell",
+                "explosives",
+                "battery",
+                "flying-robot-frame",
+                "low-density-structure",
+                "rocket-fuel",
+                "rocket-control-unit",
+                "rocket-part",
+                "science-pack-1",
+                "science-pack-2",
+                "science-pack-3",
+                "military-science-pack",
+                "production-science-pack",
+                "high-tech-science-pack"
+            ],
+            "name": "productivity-module-2",
+            "order": "c[productivity]-b[productivity-module-2]",
+            "subgroup": "module",
+            "type": "module"
+        },
+        "productivity-module-3": {
+            "category": "productivity",
+            "effect": {
+                "consumption": {
+                    "bonus": 0.8
+                },
+                "pollution": {
+                    "bonus": 0.1
+                },
+                "productivity": {
+                    "bonus": 0.1
+                },
+                "speed": {
+                    "bonus": -0.15
+                }
+            },
+            "group": "production",
+            "icon_col": 2,
+            "icon_row": 10,
+            "limitation": [
+                "sulfuric-acid",
+                "basic-oil-processing",
+                "advanced-oil-processing",
+                "coal-liquefaction",
+                "heavy-oil-cracking",
+                "light-oil-cracking",
+                "solid-fuel-from-light-oil",
+                "solid-fuel-from-heavy-oil",
+                "solid-fuel-from-petroleum-gas",
+                "lubricant",
+                "wood",
+                "iron-plate",
+                "copper-plate",
+                "steel-plate",
+                "stone-brick",
+                "sulfur",
+                "plastic-bar",
+                "empty-barrel",
+                "uranium-processing",
+                "copper-cable",
+                "iron-stick",
+                "iron-gear-wheel",
+                "electronic-circuit",
+                "advanced-circuit",
+                "processing-unit",
+                "engine-unit",
+                "electric-engine-unit",
+                "uranium-fuel-cell",
+                "explosives",
+                "battery",
+                "flying-robot-frame",
+                "low-density-structure",
+                "rocket-fuel",
+                "rocket-control-unit",
+                "rocket-part",
+                "science-pack-1",
+                "science-pack-2",
+                "science-pack-3",
+                "military-science-pack",
+                "production-science-pack",
+                "high-tech-science-pack"
+            ],
+            "name": "productivity-module-3",
+            "order": "c[productivity]-c[productivity-module-3]",
+            "subgroup": "module",
+            "type": "module"
+        },
+        "programmable-speaker": {
+            "group": "logistics",
+            "icon_col": 3,
+            "icon_row": 10,
+            "name": "programmable-speaker",
+            "order": "d[other]-b[programmable-speaker]",
+            "subgroup": "circuit-network",
+            "type": "item"
+        },
+        "pump": {
+            "group": "logistics",
+            "icon_col": 4,
+            "icon_row": 10,
+            "name": "pump",
+            "order": "b[pipe]-c[pump]",
+            "subgroup": "energy-pipe-distribution",
+            "type": "item"
+        },
+        "pumpjack": {
+            "group": "production",
+            "icon_col": 5,
+            "icon_row": 10,
+            "name": "pumpjack",
+            "order": "b[fluids]-b[pumpjack]",
+            "subgroup": "extraction-machine",
+            "type": "item"
+        },
+        "radar": {
+            "group": "combat",
+            "icon_col": 6,
+            "icon_row": 10,
+            "name": "radar",
+            "order": "d[radar]-a[radar]",
+            "subgroup": "defensive-structure",
+            "type": "item"
+        },
+        "rail": {
+            "group": "logistics",
+            "icon_col": 7,
+            "icon_row": 10,
+            "name": "rail",
+            "order": "a[train-system]-a[rail]",
+            "subgroup": "transport",
+            "type": "rail-planner"
+        },
+        "rail-chain-signal": {
+            "group": "logistics",
+            "icon_col": 8,
+            "icon_row": 10,
+            "name": "rail-chain-signal",
+            "order": "a[train-system]-e[rail-signal-chain]",
+            "subgroup": "transport",
+            "type": "item"
+        },
+        "rail-signal": {
+            "group": "logistics",
+            "icon_col": 9,
+            "icon_row": 10,
+            "name": "rail-signal",
+            "order": "a[train-system]-d[rail-signal]",
+            "subgroup": "transport",
+            "type": "item"
+        },
+        "railgun": {
+            "group": "combat",
+            "icon_col": 10,
+            "icon_row": 10,
+            "name": "railgun",
+            "order": "c[railgun]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "railgun-dart": {
+            "group": "combat",
+            "icon_col": 11,
+            "icon_row": 10,
+            "name": "railgun-dart",
+            "order": "c[railgun]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "raw-fish": {
+            "group": "intermediate-products",
+            "icon_col": 4,
+            "icon_row": 5,
+            "name": "raw-fish",
+            "order": "h[raw-fish]",
+            "subgroup": "raw-resource",
+            "type": "capsule"
+        },
+        "raw-wood": {
+            "fuel_category": "chemical",
+            "fuel_value": 4000000.0,
+            "group": "intermediate-products",
+            "icon_col": 12,
+            "icon_row": 10,
+            "name": "raw-wood",
+            "order": "a[raw-wood]",
+            "subgroup": "raw-resource",
+            "type": "item"
+        },
+        "red-wire": {
+            "group": "logistics",
+            "icon_col": 13,
+            "icon_row": 10,
+            "name": "red-wire",
+            "order": "b[wires]-a[red-wire]",
+            "subgroup": "circuit-network",
+            "type": "item"
+        },
+        "repair-pack": {
+            "group": "production",
+            "icon_col": 0,
+            "icon_row": 11,
+            "name": "repair-pack",
+            "order": "b[repair]-a[repair-pack]",
+            "subgroup": "tool",
+            "type": "repair-tool"
+        },
+        "roboport": {
+            "group": "logistics",
+            "icon_col": 1,
+            "icon_row": 11,
+            "name": "roboport",
+            "order": "c[signal]-a[roboport]",
+            "subgroup": "logistic-network",
+            "type": "item"
+        },
+        "rocket": {
+            "group": "combat",
+            "icon_col": 2,
+            "icon_row": 11,
+            "name": "rocket",
+            "order": "d[rocket-launcher]-a[basic]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "rocket-control-unit": {
+            "group": "intermediate-products",
+            "icon_col": 3,
+            "icon_row": 11,
+            "name": "rocket-control-unit",
+            "order": "o[rocket-control-unit]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "rocket-fuel": {
+            "fuel_category": "chemical",
+            "fuel_value": 225000000.0,
+            "group": "intermediate-products",
+            "icon_col": 4,
+            "icon_row": 11,
+            "name": "rocket-fuel",
+            "order": "n[rocket-fuel]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "rocket-launcher": {
+            "group": "combat",
+            "icon_col": 5,
+            "icon_row": 11,
+            "name": "rocket-launcher",
+            "order": "d[rocket-launcher]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "rocket-part": {
+            "group": "intermediate-products",
+            "icon_col": 6,
+            "icon_row": 11,
+            "name": "rocket-part",
+            "order": "p[rocket-part]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "rocket-silo": {
+            "group": "combat",
+            "icon_col": 7,
+            "icon_row": 11,
+            "name": "rocket-silo",
+            "order": "e[rocket-silo]",
+            "subgroup": "defensive-structure",
+            "type": "item"
+        },
+        "satellite": {
+            "group": "intermediate-products",
+            "icon_col": 9,
+            "icon_row": 11,
+            "name": "satellite",
+            "order": "q[satellite]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "science-pack-1": {
+            "group": "intermediate-products",
+            "icon_col": 10,
+            "icon_row": 11,
+            "name": "science-pack-1",
+            "order": "a[science-pack-1]",
+            "subgroup": "science-pack",
+            "type": "tool"
+        },
+        "science-pack-2": {
+            "group": "intermediate-products",
+            "icon_col": 11,
+            "icon_row": 11,
+            "name": "science-pack-2",
+            "order": "b[science-pack-2]",
+            "subgroup": "science-pack",
+            "type": "tool"
+        },
+        "science-pack-3": {
+            "group": "intermediate-products",
+            "icon_col": 12,
+            "icon_row": 11,
+            "name": "science-pack-3",
+            "order": "c[science-pack-3]",
+            "subgroup": "science-pack",
+            "type": "tool"
+        },
+        "shotgun": {
+            "group": "combat",
+            "icon_col": 13,
+            "icon_row": 11,
+            "name": "shotgun",
+            "order": "b[shotgun]-a[basic]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "shotgun-shell": {
+            "group": "combat",
+            "icon_col": 0,
+            "icon_row": 12,
+            "name": "shotgun-shell",
+            "order": "b[shotgun]-a[basic]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "simple-entity-with-force": {
+            "group": "other",
+            "icon_col": 9,
+            "icon_row": 13,
+            "name": "simple-entity-with-force",
+            "order": "s[simple-entity-with-force]-f[simple-entity-with-force]",
+            "subgroup": "other",
+            "type": "item"
+        },
+        "simple-entity-with-owner": {
+            "group": "other",
+            "icon_col": 8,
+            "icon_row": 15,
+            "name": "simple-entity-with-owner",
+            "order": "s[simple-entity-with-owner]-o[simple-entity-with-owner]",
+            "subgroup": "other",
+            "type": "item"
+        },
+        "slowdown-capsule": {
+            "group": "combat",
+            "icon_col": 2,
+            "icon_row": 12,
+            "name": "slowdown-capsule",
+            "order": "c[slowdown-capsule]",
+            "subgroup": "capsule",
+            "type": "capsule"
+        },
+        "small-electric-pole": {
+            "fuel_category": "chemical",
+            "fuel_value": 4000000.0,
+            "group": "logistics",
+            "icon_col": 3,
+            "icon_row": 12,
+            "name": "small-electric-pole",
+            "order": "a[energy]-a[small-electric-pole]",
+            "subgroup": "energy-pipe-distribution",
+            "type": "item"
+        },
+        "small-lamp": {
+            "group": "logistics",
+            "icon_col": 4,
+            "icon_row": 12,
+            "name": "small-lamp",
+            "order": "a[light]-a[small-lamp]",
+            "subgroup": "circuit-network",
+            "type": "item"
+        },
+        "small-plane": {
+            "group": "logistics",
+            "icon_col": 5,
+            "icon_row": 12,
+            "name": "small-plane",
+            "order": "b[personal-transport]-c[small-plane]",
+            "subgroup": "transport",
+            "type": "item"
+        },
+        "solar-panel": {
+            "group": "production",
+            "icon_col": 6,
+            "icon_row": 12,
+            "name": "solar-panel",
+            "order": "d[solar-panel]-a[solar-panel]",
+            "subgroup": "energy",
+            "type": "item"
+        },
+        "solar-panel-equipment": {
+            "group": "combat",
+            "icon_col": 7,
+            "icon_row": 12,
+            "name": "solar-panel-equipment",
+            "order": "a[energy-source]-a[solar-panel]",
+            "subgroup": "equipment",
+            "type": "item"
+        },
+        "solid-fuel": {
+            "fuel_category": "chemical",
+            "fuel_value": 25000000.0,
+            "group": "intermediate-products",
+            "icon_col": 8,
+            "icon_row": 12,
+            "name": "solid-fuel",
+            "order": "c[solid-fuel]",
+            "subgroup": "raw-material",
+            "type": "item"
+        },
+        "space-science-pack": {
+            "group": "intermediate-products",
+            "icon_col": 12,
+            "icon_row": 12,
+            "name": "space-science-pack",
+            "order": "g[space-science-pack]",
+            "subgroup": "science-pack",
+            "type": "tool"
+        },
+        "speed-module": {
+            "category": "speed",
+            "effect": {
+                "consumption": {
+                    "bonus": 0.5
+                },
+                "speed": {
+                    "bonus": 0.2
+                }
+            },
+            "group": "production",
+            "icon_col": 13,
+            "icon_row": 12,
+            "name": "speed-module",
+            "order": "a[speed]-a[speed-module-1]",
+            "subgroup": "module",
+            "type": "module"
+        },
+        "speed-module-2": {
+            "category": "speed",
+            "effect": {
+                "consumption": {
+                    "bonus": 0.6
+                },
+                "speed": {
+                    "bonus": 0.3
+                }
+            },
+            "group": "production",
+            "icon_col": 0,
+            "icon_row": 13,
+            "name": "speed-module-2",
+            "order": "a[speed]-b[speed-module-2]",
+            "subgroup": "module",
+            "type": "module"
+        },
+        "speed-module-3": {
+            "category": "speed",
+            "effect": {
+                "consumption": {
+                    "bonus": 0.7
+                },
+                "speed": {
+                    "bonus": 0.5
+                }
+            },
+            "group": "production",
+            "icon_col": 1,
+            "icon_row": 13,
+            "name": "speed-module-3",
+            "order": "a[speed]-c[speed-module-3]",
+            "subgroup": "module",
+            "type": "module"
+        },
+        "splitter": {
+            "group": "logistics",
+            "icon_col": 2,
+            "icon_row": 13,
+            "name": "splitter",
+            "order": "c[splitter]-a[splitter]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "stack-filter-inserter": {
+            "group": "logistics",
+            "icon_col": 3,
+            "icon_row": 13,
+            "name": "stack-filter-inserter",
+            "order": "g[stack-filter-inserter]",
+            "subgroup": "inserter",
+            "type": "item"
+        },
+        "stack-inserter": {
+            "group": "logistics",
+            "icon_col": 4,
+            "icon_row": 13,
+            "name": "stack-inserter",
+            "order": "f[stack-inserter]",
+            "subgroup": "inserter",
+            "type": "item"
+        },
+        "steam": {
+            "group": "other",
+            "icon_col": 5,
+            "icon_row": 13,
+            "name": "steam",
+            "order": "a[fluid]-b[steam]",
+            "subgroup": "other",
+            "type": "fluid"
+        },
+        "steam-engine": {
+            "group": "production",
+            "icon_col": 6,
+            "icon_row": 13,
+            "name": "steam-engine",
+            "order": "b[steam-power]-b[steam-engine]",
+            "subgroup": "energy",
+            "type": "item"
+        },
+        "steam-turbine": {
+            "group": "production",
+            "icon_col": 7,
+            "icon_row": 13,
+            "name": "steam-turbine",
+            "order": "b[steam-power]-c[steam-turbine]",
+            "subgroup": "energy",
+            "type": "item"
+        },
+        "steel-axe": {
+            "group": "production",
+            "icon_col": 8,
+            "icon_row": 13,
+            "name": "steel-axe",
+            "order": "a[mining]-b[steel-axe]",
+            "subgroup": "tool",
+            "type": "mining-tool"
+        },
+        "steel-chest": {
+            "group": "logistics",
+            "icon_col": 9,
+            "icon_row": 13,
+            "name": "steel-chest",
+            "order": "a[items]-c[steel-chest]",
+            "subgroup": "storage",
+            "type": "item"
+        },
+        "steel-furnace": {
+            "group": "production",
+            "icon_col": 10,
+            "icon_row": 13,
+            "name": "steel-furnace",
+            "order": "b[steel-furnace]",
+            "subgroup": "smelting-machine",
+            "type": "item"
+        },
+        "steel-plate": {
+            "group": "intermediate-products",
+            "icon_col": 11,
+            "icon_row": 13,
+            "name": "steel-plate",
+            "order": "d[steel-plate]",
+            "subgroup": "raw-material",
+            "type": "item"
+        },
+        "stone": {
+            "group": "intermediate-products",
+            "icon_col": 12,
+            "icon_row": 13,
+            "name": "stone",
+            "order": "d[stone]",
+            "subgroup": "raw-resource",
+            "type": "item"
+        },
+        "stone-brick": {
+            "group": "logistics",
+            "icon_col": 13,
+            "icon_row": 13,
+            "name": "stone-brick",
+            "order": "a[stone-brick]",
+            "subgroup": "terrain",
+            "type": "item"
+        },
+        "stone-furnace": {
+            "group": "production",
+            "icon_col": 0,
+            "icon_row": 14,
+            "name": "stone-furnace",
+            "order": "a[stone-furnace]",
+            "subgroup": "smelting-machine",
+            "type": "item"
+        },
+        "stone-wall": {
+            "group": "combat",
+            "icon_col": 1,
+            "icon_row": 14,
+            "name": "stone-wall",
+            "order": "a[stone-wall]-a[stone-wall]",
+            "subgroup": "defensive-structure",
+            "type": "item"
+        },
+        "storage-tank": {
+            "group": "logistics",
+            "icon_col": 2,
+            "icon_row": 14,
+            "name": "storage-tank",
+            "order": "b[fluid]-a[storage-tank]",
+            "subgroup": "storage",
+            "type": "item"
+        },
+        "submachine-gun": {
+            "group": "combat",
+            "icon_col": 3,
+            "icon_row": 14,
+            "name": "submachine-gun",
+            "order": "a[basic-clips]-b[submachine-gun]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "substation": {
+            "group": "logistics",
+            "icon_col": 4,
+            "icon_row": 14,
+            "name": "substation",
+            "order": "a[energy]-d[substation]",
+            "subgroup": "energy-pipe-distribution",
+            "type": "item"
+        },
+        "sulfur": {
+            "group": "intermediate-products",
+            "icon_col": 5,
+            "icon_row": 14,
+            "name": "sulfur",
+            "order": "f[sulfur]",
+            "subgroup": "raw-material",
+            "type": "item"
+        },
+        "sulfuric-acid": {
+            "group": "other",
+            "icon_col": 6,
+            "icon_row": 14,
+            "name": "sulfuric-acid",
+            "order": "a[fluid]-f[sulfuric-acid]",
+            "subgroup": "other",
+            "type": "fluid"
+        },
+        "tank": {
+            "group": "logistics",
+            "icon_col": 7,
+            "icon_row": 14,
+            "name": "tank",
+            "order": "b[personal-transport]-b[tank]",
+            "subgroup": "transport",
+            "type": "item-with-entity-data"
+        },
+        "tank-cannon": {
+            "group": "combat",
+            "icon_col": 8,
+            "icon_row": 14,
+            "name": "tank-cannon",
+            "order": "z[tank]-a[cannon]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "tank-flamethrower": {
+            "group": "combat",
+            "icon_col": 5,
+            "icon_row": 5,
+            "name": "tank-flamethrower",
+            "order": "b[flamethrower]-b[tank-flamethrower]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "tank-machine-gun": {
+            "group": "combat",
+            "icon_col": 3,
+            "icon_row": 14,
+            "name": "tank-machine-gun",
+            "order": "a[basic-clips]-b[tank-machine-gun]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "train-stop": {
+            "group": "logistics",
+            "icon_col": 9,
+            "icon_row": 14,
+            "name": "train-stop",
+            "order": "a[train-system]-c[train-stop]",
+            "subgroup": "transport",
+            "type": "item"
+        },
+        "transport-belt": {
+            "group": "logistics",
+            "icon_col": 10,
+            "icon_row": 14,
+            "name": "transport-belt",
+            "order": "a[transport-belt]-a[transport-belt]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "underground-belt": {
+            "group": "logistics",
+            "icon_col": 11,
+            "icon_row": 14,
+            "name": "underground-belt",
+            "order": "b[underground-belt]-a[underground-belt]",
+            "subgroup": "belt",
+            "type": "item"
+        },
+        "uranium-235": {
+            "group": "intermediate-products",
+            "icon_col": 12,
+            "icon_row": 14,
+            "name": "uranium-235",
+            "order": "r[uranium-235]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "uranium-238": {
+            "group": "intermediate-products",
+            "icon_col": 13,
+            "icon_row": 14,
+            "name": "uranium-238",
+            "order": "r[uranium-238]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "uranium-cannon-shell": {
+            "group": "combat",
+            "icon_col": 0,
+            "icon_row": 15,
+            "name": "uranium-cannon-shell",
+            "order": "d[cannon-shell]-c[uranium]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "uranium-fuel-cell": {
+            "fuel_category": "nuclear",
+            "fuel_value": 8000000000.0,
+            "group": "intermediate-products",
+            "icon_col": 1,
+            "icon_row": 15,
+            "name": "uranium-fuel-cell",
+            "order": "r[uranium-processing]-a[uranium-fuel-cell]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "uranium-ore": {
+            "group": "intermediate-products",
+            "icon_col": 2,
+            "icon_row": 15,
+            "name": "uranium-ore",
+            "order": "g[uranium-ore]",
+            "subgroup": "raw-resource",
+            "type": "item"
+        },
+        "uranium-rounds-magazine": {
+            "group": "combat",
+            "icon_col": 4,
+            "icon_row": 15,
+            "name": "uranium-rounds-magazine",
+            "order": "a[basic-clips]-c[uranium-rounds-magazine]",
+            "subgroup": "ammo",
+            "type": "ammo"
+        },
+        "used-up-uranium-fuel-cell": {
+            "group": "intermediate-products",
+            "icon_col": 5,
+            "icon_row": 15,
+            "name": "used-up-uranium-fuel-cell",
+            "order": "r[used-up-uranium-fuel-cell]",
+            "subgroup": "intermediate-product",
+            "type": "item"
+        },
+        "vehicle-machine-gun": {
+            "group": "combat",
+            "icon_col": 3,
+            "icon_row": 14,
+            "name": "vehicle-machine-gun",
+            "order": "a[basic-clips]-b[vehicle-machine-gun]",
+            "subgroup": "gun",
+            "type": "gun"
+        },
+        "water": {
+            "group": "other",
+            "icon_col": 6,
+            "icon_row": 15,
+            "name": "water",
+            "order": "a[fluid]-a[water]",
+            "subgroup": "other",
+            "type": "fluid"
+        },
+        "wood": {
+            "fuel_category": "chemical",
+            "fuel_value": 2000000.0,
+            "group": "intermediate-products",
+            "icon_col": 7,
+            "icon_row": 15,
+            "name": "wood",
+            "order": "a[wood]",
+            "subgroup": "raw-material",
+            "type": "item"
+        },
+        "wooden-chest": {
+            "fuel_category": "chemical",
+            "fuel_value": 4000000.0,
+            "group": "logistics",
+            "icon_col": 8,
+            "icon_row": 15,
+            "name": "wooden-chest",
+            "order": "a[items]-a[wooden-chest]",
+            "subgroup": "storage",
+            "type": "item"
+        }
+    },
+    "mining-drill": {
+        "burner-mining-drill": {
+            "energy_source": {
+                "effectivity": 1,
+                "emissions": 0.033333333333333,
+                "fuel_category": "chemical",
+                "fuel_inventory_size": 1,
+                "smoke": [
+                    {
+                        "deviation": [
+                            0.1,
+                            0.1
+                        ],
+                        "frequency": 3,
+                        "name": "smoke"
+                    }
+                ],
+                "type": "burner"
+            },
+            "energy_usage": 300000.0,
+            "icon_col": 5,
+            "icon_row": 1,
+            "mining_power": 2.5,
+            "mining_speed": 0.35,
+            "module_slots": 0,
+            "name": "burner-mining-drill",
+            "resource_categories": [
+                "basic-solid"
+            ]
+        },
+        "electric-mining-drill": {
+            "energy_source": {
+                "emissions": 0.1,
+                "type": "electric",
+                "usage_priority": "secondary-input"
+            },
+            "energy_usage": 90000.0,
+            "icon_col": 10,
+            "icon_row": 3,
+            "mining_power": 3,
+            "mining_speed": 0.5,
+            "module_slots": 3,
+            "name": "electric-mining-drill",
+            "resource_categories": [
+                "basic-solid"
+            ]
+        },
+        "pumpjack": {
+            "energy_source": {
+                "emissions": 0.1,
+                "type": "electric",
+                "usage_priority": "secondary-input"
+            },
+            "energy_usage": 90000.0,
+            "icon_col": 5,
+            "icon_row": 10,
+            "mining_power": 2,
+            "mining_speed": 1,
+            "module_slots": 2,
+            "name": "pumpjack",
+            "resource_categories": [
+                "basic-fluid"
+            ]
+        }
+    },
+    "modules": [
+        "effectivity-module",
+        "effectivity-module-2",
+        "effectivity-module-3",
+        "productivity-module",
+        "productivity-module-2",
+        "productivity-module-3",
+        "speed-module",
+        "speed-module-2",
+        "speed-module-3"
+    ],
+    "offshore-pump": {
+        "offshore-pump": {
+            "fluid": "water",
+            "icon_col": 9,
+            "icon_row": 8,
+            "name": "offshore-pump",
+            "pumping_speed": 20
+        }
+    },
+    "reactor": {
+        "nuclear-reactor": {
+            "burner": {
+                "burnt_inventory_size": 1,
+                "effectivity": 1,
+                "fuel_category": "nuclear",
+                "fuel_inventory_size": 1
+            },
+            "consumption": "40MW",
+            "icon_col": 8,
+            "icon_row": 8,
+            "name": "nuclear-reactor"
+        }
+    },
+    "recipes": {
+        "accumulator": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 0,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "battery"
+                }
+            ],
+            "name": "accumulator",
+            "order": "e[accumulator]-a[accumulator]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "accumulator"
+                }
+            ],
+            "subgroup": "energy",
+            "type": "recipe"
+        },
+        "advanced-circuit": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 6,
+            "icon_col": 1,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 2,
+                    "name": "plastic-bar"
+                },
+                {
+                    "amount": 4,
+                    "name": "copper-cable"
+                }
+            ],
+            "name": "advanced-circuit",
+            "order": "f[advanced-circuit]",
+            "requester_paste_multiplier": 5,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "advanced-circuit"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "advanced-oil-processing": {
+            "category": "oil-processing",
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 2,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 50,
+                    "name": "water",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 100,
+                    "name": "crude-oil",
+                    "type": "fluid"
+                }
+            ],
+            "name": "advanced-oil-processing",
+            "order": "a[oil-processing]-b[advanced-oil-processing]",
+            "results": [
+                {
+                    "amount": 10,
+                    "name": "heavy-oil",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 45,
+                    "name": "light-oil",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 55,
+                    "name": "petroleum-gas",
+                    "type": "fluid"
+                }
+            ],
+            "subgroup": "fluid-recipes",
+            "type": "recipe"
+        },
+        "arithmetic-combinator": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 3,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "copper-cable"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "arithmetic-combinator",
+            "order": "c[combinators]-a[arithmetic-combinator]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "arithmetic-combinator"
+                }
+            ],
+            "subgroup": "circuit-network",
+            "type": "recipe"
+        },
+        "assembling-machine-1": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 4,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 3,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 9,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "assembling-machine-1",
+            "order": "a[assembling-machine-1]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "assembling-machine-1"
+                }
+            ],
+            "subgroup": "production-machine",
+            "type": "recipe"
+        },
+        "assembling-machine-2": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 5,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 9,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 3,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 1,
+                    "name": "assembling-machine-1"
+                }
+            ],
+            "name": "assembling-machine-2",
+            "order": "b[assembling-machine-2]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "assembling-machine-2"
+                }
+            ],
+            "subgroup": "production-machine",
+            "type": "recipe"
+        },
+        "assembling-machine-3": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 6,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 4,
+                    "name": "speed-module"
+                },
+                {
+                    "amount": 2,
+                    "name": "assembling-machine-2"
+                }
+            ],
+            "name": "assembling-machine-3",
+            "order": "c[assembling-machine-3]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "assembling-machine-3"
+                }
+            ],
+            "subgroup": "production-machine",
+            "type": "recipe"
+        },
+        "atomic-bomb": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 50,
+            "icon_col": 7,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "processing-unit"
+                },
+                {
+                    "amount": 10,
+                    "name": "explosives"
+                },
+                {
+                    "amount": 30,
+                    "name": "uranium-235"
+                }
+            ],
+            "name": "atomic-bomb",
+            "order": "d[rocket-launcher]-c[atomic-bomb]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "atomic-bomb"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "basic-oil-processing": {
+            "category": "oil-processing",
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 8,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 100,
+                    "name": "crude-oil",
+                    "type": "fluid"
+                }
+            ],
+            "name": "basic-oil-processing",
+            "order": "a[oil-processing]-a[basic-oil-processing]",
+            "results": [
+                {
+                    "amount": 30,
+                    "name": "heavy-oil",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 30,
+                    "name": "light-oil",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 40,
+                    "name": "petroleum-gas",
+                    "type": "fluid"
+                }
+            ],
+            "subgroup": "fluid-recipes",
+            "type": "recipe"
+        },
+        "battery": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.611,
+                    "r": 0.97
+                },
+                "secondary": {
+                    "a": 0.357,
+                    "b": 0.894,
+                    "g": 0.68,
+                    "r": 0
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0.726,
+                    "g": 0.805,
+                    "r": 0.43
+                }
+            },
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 9,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "sulfuric-acid",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 1,
+                    "name": "copper-plate"
+                }
+            ],
+            "name": "battery",
+            "order": "j[battery]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "battery"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "battery-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 10,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "battery"
+                },
+                {
+                    "amount": 10,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "battery-equipment",
+            "order": "c[battery]-a[battery-equipment]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "battery-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "battery-mk2-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 11,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "battery-equipment"
+                },
+                {
+                    "amount": 20,
+                    "name": "processing-unit"
+                }
+            ],
+            "name": "battery-mk2-equipment",
+            "order": "c[battery]-b[battery-equipment-mk2]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "battery-mk2-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "beacon": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 15,
+            "icon_col": 12,
+            "icon_row": 0,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 20,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 10,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "copper-cable"
+                }
+            ],
+            "name": "beacon",
+            "order": "a[beacon]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "beacon"
+                }
+            ],
+            "subgroup": "module",
+            "type": "recipe"
+        },
+        "big-electric-pole": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 0,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "copper-plate"
+                }
+            ],
+            "name": "big-electric-pole",
+            "order": "a[energy]-c[big-electric-pole]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "big-electric-pole"
+                }
+            ],
+            "subgroup": "energy-pipe-distribution",
+            "type": "recipe"
+        },
+        "boiler": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 3,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "stone-furnace"
+                },
+                {
+                    "amount": 4,
+                    "name": "pipe"
+                }
+            ],
+            "name": "boiler",
+            "order": "b[steam-power]-a[boiler]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "boiler"
+                }
+            ],
+            "subgroup": "energy",
+            "type": "recipe"
+        },
+        "burner-inserter": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 4,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-gear-wheel"
+                }
+            ],
+            "name": "burner-inserter",
+            "order": "a[burner-inserter]",
+            "requester_paste_multiplier": 15,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "burner-inserter"
+                }
+            ],
+            "subgroup": "inserter",
+            "type": "recipe"
+        },
+        "burner-mining-drill": {
+            "category": "crafting",
+            "energy_required": 2,
+            "icon_col": 5,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 3,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 1,
+                    "name": "stone-furnace"
+                },
+                {
+                    "amount": 3,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "burner-mining-drill",
+            "order": "a[items]-a[burner-mining-drill]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "burner-mining-drill"
+                }
+            ],
+            "subgroup": "extraction-machine",
+            "type": "recipe"
+        },
+        "cannon-shell": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 6,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 2,
+                    "name": "plastic-bar"
+                },
+                {
+                    "amount": 1,
+                    "name": "explosives"
+                }
+            ],
+            "name": "cannon-shell",
+            "order": "d[cannon-shell]-a[basic]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "cannon-shell"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "car": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 2,
+            "icon_col": 7,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 8,
+                    "name": "engine-unit"
+                },
+                {
+                    "amount": 20,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "car",
+            "order": "b[personal-transport]-a[car]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "car"
+                }
+            ],
+            "subgroup": "transport",
+            "type": "recipe"
+        },
+        "cargo-wagon": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 1,
+            "icon_col": 8,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 20,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 20,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "cargo-wagon",
+            "order": "a[train-system]-g[cargo-wagon]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "cargo-wagon"
+                }
+            ],
+            "subgroup": "transport",
+            "type": "recipe"
+        },
+        "centrifuge": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 4,
+            "icon_col": 9,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 100,
+                    "name": "concrete"
+                },
+                {
+                    "amount": 50,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 100,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 100,
+                    "name": "iron-gear-wheel"
+                }
+            ],
+            "name": "centrifuge",
+            "order": "g[centrifuge]",
+            "requester_paste_multiplier": 2,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "centrifuge"
+                }
+            ],
+            "subgroup": "production-machine",
+            "type": "recipe"
+        },
+        "chemical-plant": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 10,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "pipe"
+                }
+            ],
+            "name": "chemical-plant",
+            "order": "e[chemical-plant]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "chemical-plant"
+                }
+            ],
+            "subgroup": "production-machine",
+            "type": "recipe"
+        },
+        "cluster-grenade": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 11,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 7,
+                    "name": "grenade"
+                },
+                {
+                    "amount": 5,
+                    "name": "explosives"
+                },
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "cluster-grenade",
+            "order": "a[grenade]-b[cluster]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "cluster-grenade"
+                }
+            ],
+            "subgroup": "capsule",
+            "type": "recipe"
+        },
+        "coal-liquefaction": {
+            "allow_decomposition": false,
+            "category": "oil-processing",
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 13,
+            "icon_row": 1,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "coal",
+                    "type": "item"
+                },
+                {
+                    "amount": 25,
+                    "name": "heavy-oil",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 50,
+                    "name": "steam",
+                    "type": "fluid"
+                }
+            ],
+            "name": "coal-liquefaction",
+            "order": "a[oil-processing]-c[coal-liquefaction]",
+            "results": [
+                {
+                    "amount": 35,
+                    "name": "heavy-oil",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 15,
+                    "name": "light-oil",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 20,
+                    "name": "petroleum-gas",
+                    "type": "fluid"
+                }
+            ],
+            "subgroup": "fluid-recipes",
+            "type": "recipe"
+        },
+        "combat-shotgun": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 1,
+            "icon_row": 2,
+            "ingredients": [
+                {
+                    "amount": 15,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 10,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "wood"
+                }
+            ],
+            "name": "combat-shotgun",
+            "order": "b[shotgun]-a[combat]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "combat-shotgun"
+                }
+            ],
+            "subgroup": "gun",
+            "type": "recipe"
+        },
+        "concrete": {
+            "category": "crafting-with-fluid",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 3,
+            "icon_row": 2,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "stone-brick"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-ore"
+                },
+                {
+                    "amount": 100,
+                    "name": "water",
+                    "type": "fluid"
+                }
+            ],
+            "name": "concrete",
+            "order": "b[concrete]-a[plain]",
+            "results": [
+                {
+                    "amount": 10,
+                    "name": "concrete"
+                }
+            ],
+            "subgroup": "terrain",
+            "type": "recipe"
+        },
+        "constant-combinator": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 4,
+            "icon_row": 2,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "copper-cable"
+                },
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "constant-combinator",
+            "order": "c[combinators]-c[constant-combinator]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "constant-combinator"
+                }
+            ],
+            "subgroup": "circuit-network",
+            "type": "recipe"
+        },
+        "construction-robot": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 5,
+            "icon_row": 2,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "flying-robot-frame"
+                },
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "construction-robot",
+            "order": "a[robot]-b[construction-robot]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "construction-robot"
+                }
+            ],
+            "subgroup": "logistic-network",
+            "type": "recipe"
+        },
+        "copper-cable": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 6,
+            "icon_row": 2,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "copper-plate"
+                }
+            ],
+            "name": "copper-cable",
+            "order": "a[copper-cable]",
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "copper-cable"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "copper-plate": {
+            "category": "smelting",
+            "energy_required": 3.5,
+            "icon_col": 8,
+            "icon_row": 2,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "copper-ore"
+                }
+            ],
+            "name": "copper-plate",
+            "order": "c[copper-plate]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "copper-plate"
+                }
+            ],
+            "subgroup": "raw-material",
+            "type": "recipe"
+        },
+        "decider-combinator": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 11,
+            "icon_row": 2,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "copper-cable"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "decider-combinator",
+            "order": "c[combinators]-b[decider-combinator]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "decider-combinator"
+                }
+            ],
+            "subgroup": "circuit-network",
+            "type": "recipe"
+        },
+        "defender-capsule": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 13,
+            "icon_row": 2,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "piercing-rounds-magazine"
+                },
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 3,
+                    "name": "iron-gear-wheel"
+                }
+            ],
+            "name": "defender-capsule",
+            "order": "d[defender-capsule]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "defender-capsule"
+                }
+            ],
+            "subgroup": "capsule",
+            "type": "recipe"
+        },
+        "destroyer-capsule": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 15,
+            "icon_col": 0,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 4,
+                    "name": "distractor-capsule"
+                },
+                {
+                    "amount": 1,
+                    "name": "speed-module"
+                }
+            ],
+            "name": "destroyer-capsule",
+            "order": "f[destroyer-capsule]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "destroyer-capsule"
+                }
+            ],
+            "subgroup": "capsule",
+            "type": "recipe"
+        },
+        "discharge-defense-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 2,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "processing-unit"
+                },
+                {
+                    "amount": 20,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "laser-turret"
+                }
+            ],
+            "name": "discharge-defense-equipment",
+            "order": "d[active-defense]-b[discharge-defense-equipment]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "discharge-defense-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "discharge-defense-remote": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 3,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "discharge-defense-remote",
+            "order": "z",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "discharge-defense-remote"
+                }
+            ],
+            "subgroup": "capsule",
+            "type": "recipe"
+        },
+        "distractor-capsule": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 15,
+            "icon_col": 4,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 4,
+                    "name": "defender-capsule"
+                },
+                {
+                    "amount": 3,
+                    "name": "advanced-circuit"
+                }
+            ],
+            "name": "distractor-capsule",
+            "order": "e[defender-capsule]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "distractor-capsule"
+                }
+            ],
+            "subgroup": "capsule",
+            "type": "recipe"
+        },
+        "effectivity-module": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 15,
+            "icon_col": 5,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "effectivity-module",
+            "order": "c[effectivity]-a[effectivity-module-1]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "effectivity-module"
+                }
+            ],
+            "subgroup": "module",
+            "type": "recipe"
+        },
+        "effectivity-module-2": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 30,
+            "icon_col": 6,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 4,
+                    "name": "effectivity-module"
+                },
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "processing-unit"
+                }
+            ],
+            "name": "effectivity-module-2",
+            "order": "c[effectivity]-b[effectivity-module-2]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "effectivity-module-2"
+                }
+            ],
+            "subgroup": "module",
+            "type": "recipe"
+        },
+        "effectivity-module-3": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 60,
+            "icon_col": 7,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "effectivity-module-2"
+                },
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "processing-unit"
+                }
+            ],
+            "name": "effectivity-module-3",
+            "order": "c[effectivity]-c[effectivity-module-3]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "effectivity-module-3"
+                }
+            ],
+            "subgroup": "module",
+            "type": "recipe"
+        },
+        "electric-engine-unit": {
+            "category": "crafting-with-fluid",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 8,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "engine-unit"
+                },
+                {
+                    "amount": 15,
+                    "name": "lubricant",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "electric-engine-unit",
+            "order": "i[electric-engine-unit]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "electric-engine-unit"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "electric-furnace": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 9,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 10,
+                    "name": "stone-brick"
+                }
+            ],
+            "name": "electric-furnace",
+            "order": "c[electric-furnace]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "electric-furnace"
+                }
+            ],
+            "subgroup": "smelting-machine",
+            "type": "recipe"
+        },
+        "electric-mining-drill": {
+            "category": "crafting",
+            "energy_required": 2,
+            "icon_col": 10,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 3,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "electric-mining-drill",
+            "order": "a[items]-b[electric-mining-drill]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "electric-mining-drill"
+                }
+            ],
+            "subgroup": "extraction-machine",
+            "type": "recipe"
+        },
+        "electronic-circuit": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 11,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 3,
+                    "name": "copper-cable"
+                }
+            ],
+            "name": "electronic-circuit",
+            "order": "e[electronic-circuit]",
+            "requester_paste_multiplier": 50,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "empty-barrel": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 1,
+            "icon_col": 12,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "steel-plate",
+                    "type": "item"
+                }
+            ],
+            "name": "empty-barrel",
+            "order": "d[empty-barrel]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "empty-barrel",
+                    "type": "item"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "energy-shield-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 13,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 10,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "energy-shield-equipment",
+            "order": "b[shield]-a[energy-shield-equipment]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "energy-shield-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "energy-shield-mk2-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 0,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "energy-shield-equipment"
+                },
+                {
+                    "amount": 10,
+                    "name": "processing-unit"
+                }
+            ],
+            "name": "energy-shield-mk2-equipment",
+            "order": "b[shield]-b[energy-shield-equipment-mk2]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "energy-shield-mk2-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "engine-unit": {
+            "category": "advanced-crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 1,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 2,
+                    "name": "pipe"
+                }
+            ],
+            "name": "engine-unit",
+            "order": "h[engine-unit]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "engine-unit"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "exoskeleton-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 2,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "processing-unit"
+                },
+                {
+                    "amount": 30,
+                    "name": "electric-engine-unit"
+                },
+                {
+                    "amount": 20,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "exoskeleton-equipment",
+            "order": "e[exoskeleton]-a[exoskeleton-equipment]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "exoskeleton-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "explosive-cannon-shell": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 3,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 2,
+                    "name": "plastic-bar"
+                },
+                {
+                    "amount": 2,
+                    "name": "explosives"
+                }
+            ],
+            "name": "explosive-cannon-shell",
+            "order": "d[cannon-shell]-c[explosive]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "explosive-cannon-shell"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "explosive-rocket": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 4,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "rocket"
+                },
+                {
+                    "amount": 2,
+                    "name": "explosives"
+                }
+            ],
+            "name": "explosive-rocket",
+            "order": "d[rocket-launcher]-b[explosive]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "explosive-rocket"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "explosive-uranium-cannon-shell": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 12,
+            "icon_col": 5,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "explosive-cannon-shell"
+                },
+                {
+                    "amount": 1,
+                    "name": "uranium-238"
+                }
+            ],
+            "name": "explosive-uranium-cannon-shell",
+            "order": "d[explosive-cannon-shell]-c[uranium]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "explosive-uranium-cannon-shell"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "explosives": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.945,
+                    "r": 0.955
+                },
+                "secondary": {
+                    "a": 0.898,
+                    "b": 0.659,
+                    "g": 0.441,
+                    "r": 0
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0.365,
+                    "g": 0.288,
+                    "r": 0
+                }
+            },
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 6,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "sulfur",
+                    "type": "item"
+                },
+                {
+                    "amount": 1,
+                    "name": "coal",
+                    "type": "item"
+                },
+                {
+                    "amount": 10,
+                    "name": "water",
+                    "type": "fluid"
+                }
+            ],
+            "name": "explosives",
+            "order": "j[explosives]",
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "explosives"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "express-loader": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 7,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "express-transport-belt"
+                },
+                {
+                    "amount": 1,
+                    "name": "fast-loader"
+                }
+            ],
+            "name": "express-loader",
+            "order": "d[loader]-c[express-loader]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "express-loader"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "express-splitter": {
+            "category": "crafting-with-fluid",
+            "enabled": false,
+            "energy_required": 2,
+            "icon_col": 8,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "fast-splitter"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 10,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 80,
+                    "name": "lubricant",
+                    "type": "fluid"
+                }
+            ],
+            "name": "express-splitter",
+            "order": "c[splitter]-c[express-splitter]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "express-splitter"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "express-transport-belt": {
+            "category": "crafting-with-fluid",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 9,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 1,
+                    "name": "fast-transport-belt"
+                },
+                {
+                    "amount": 20,
+                    "name": "lubricant",
+                    "type": "fluid"
+                }
+            ],
+            "name": "express-transport-belt",
+            "order": "a[transport-belt]-c[express-transport-belt]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "express-transport-belt"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "express-underground-belt": {
+            "category": "crafting-with-fluid",
+            "enabled": false,
+            "energy_required": 2,
+            "icon_col": 10,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 80,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 2,
+                    "name": "fast-underground-belt"
+                },
+                {
+                    "amount": 40,
+                    "name": "lubricant",
+                    "type": "fluid"
+                }
+            ],
+            "name": "express-underground-belt",
+            "order": "b[underground-belt]-c[express-underground-belt]",
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "express-underground-belt"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "fast-inserter": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 11,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 2,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 1,
+                    "name": "inserter"
+                }
+            ],
+            "name": "fast-inserter",
+            "order": "d[fast-inserter]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "fast-inserter"
+                }
+            ],
+            "subgroup": "inserter",
+            "type": "recipe"
+        },
+        "fast-loader": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 12,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "fast-transport-belt"
+                },
+                {
+                    "amount": 1,
+                    "name": "loader"
+                }
+            ],
+            "name": "fast-loader",
+            "order": "d[loader]-b[fast-loader]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "fast-loader"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "fast-splitter": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 2,
+            "icon_col": 13,
+            "icon_row": 4,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "splitter"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 10,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "fast-splitter",
+            "order": "c[splitter]-b[fast-splitter]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "fast-splitter"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "fast-transport-belt": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 0,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 1,
+                    "name": "transport-belt"
+                }
+            ],
+            "name": "fast-transport-belt",
+            "order": "a[transport-belt]-b[fast-transport-belt]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "fast-transport-belt"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "fast-underground-belt": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 2,
+            "icon_col": 1,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 40,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 2,
+                    "name": "underground-belt"
+                }
+            ],
+            "name": "fast-underground-belt",
+            "order": "b[underground-belt]-b[fast-underground-belt]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "fast-underground-belt"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "filter-inserter": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 2,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "fast-inserter"
+                },
+                {
+                    "amount": 4,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "filter-inserter",
+            "order": "e[filter-inserter]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "filter-inserter"
+                }
+            ],
+            "subgroup": "inserter",
+            "type": "recipe"
+        },
+        "firearm-magazine": {
+            "category": "crafting",
+            "energy_required": 1,
+            "icon_col": 3,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 4,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "firearm-magazine",
+            "order": "a[basic-clips]-a[firearm-magazine]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "firearm-magazine"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "flamethrower": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 5,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                }
+            ],
+            "name": "flamethrower",
+            "order": "e[flamethrower]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "flamethrower"
+                }
+            ],
+            "subgroup": "gun",
+            "type": "recipe"
+        },
+        "flamethrower-ammo": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.533,
+                    "r": 0.845
+                },
+                "secondary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0,
+                    "r": 0.655
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.329,
+                    "r": 0.685
+                }
+            },
+            "enabled": false,
+            "energy_required": 6,
+            "icon_col": 6,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "steel-plate",
+                    "type": "item"
+                },
+                {
+                    "amount": 50,
+                    "name": "light-oil",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 50,
+                    "name": "heavy-oil",
+                    "type": "fluid"
+                }
+            ],
+            "name": "flamethrower-ammo",
+            "order": "e[flamethrower]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "flamethrower-ammo"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "flamethrower-turret": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 20,
+            "icon_col": 7,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 30,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 15,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 10,
+                    "name": "pipe"
+                },
+                {
+                    "amount": 5,
+                    "name": "engine-unit"
+                }
+            ],
+            "name": "flamethrower-turret",
+            "order": "b[turret]-c[flamethrower-turret]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "flamethrower-turret"
+                }
+            ],
+            "subgroup": "defensive-structure",
+            "type": "recipe"
+        },
+        "fluid-wagon": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 1.5,
+            "icon_col": 8,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 16,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 8,
+                    "name": "pipe"
+                },
+                {
+                    "amount": 3,
+                    "name": "storage-tank"
+                }
+            ],
+            "name": "fluid-wagon",
+            "order": "a[train-system]-h[fluid-wagon]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "fluid-wagon"
+                }
+            ],
+            "subgroup": "transport",
+            "type": "recipe"
+        },
+        "flying-robot-frame": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 20,
+            "icon_col": 9,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "electric-engine-unit"
+                },
+                {
+                    "amount": 2,
+                    "name": "battery"
+                },
+                {
+                    "amount": 1,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 3,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "flying-robot-frame",
+            "order": "l[flying-robot-frame]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "flying-robot-frame"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "fusion-reactor-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 10,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 250,
+                    "name": "processing-unit"
+                }
+            ],
+            "name": "fusion-reactor-equipment",
+            "order": "a[energy-source]-b[fusion-reactor]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "fusion-reactor-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "gate": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 11,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "stone-wall"
+                },
+                {
+                    "amount": 2,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "gate",
+            "order": "a[wall]-b[gate]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "gate"
+                }
+            ],
+            "subgroup": "defensive-structure",
+            "type": "recipe"
+        },
+        "green-wire": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 12,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "copper-cable"
+                }
+            ],
+            "name": "green-wire",
+            "order": "b[wires]-b[green-wire]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "green-wire"
+                }
+            ],
+            "subgroup": "circuit-network",
+            "type": "recipe"
+        },
+        "grenade": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 13,
+            "icon_row": 5,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "coal"
+                }
+            ],
+            "name": "grenade",
+            "order": "a[grenade]-a[normal]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "grenade"
+                }
+            ],
+            "subgroup": "capsule",
+            "type": "recipe"
+        },
+        "gun-turret": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 0,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 10,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 20,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "gun-turret",
+            "order": "b[turret]-a[gun-turret]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "gun-turret"
+                }
+            ],
+            "subgroup": "defensive-structure",
+            "type": "recipe"
+        },
+        "hazard-concrete": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.25,
+            "icon_col": 1,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "concrete"
+                }
+            ],
+            "name": "hazard-concrete",
+            "order": "b[concrete]-b[hazard]",
+            "results": [
+                {
+                    "amount": 10,
+                    "name": "hazard-concrete"
+                }
+            ],
+            "subgroup": "terrain",
+            "type": "recipe"
+        },
+        "heat-exchanger": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 2,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 100,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "pipe"
+                }
+            ],
+            "name": "heat-exchanger",
+            "order": "f[nuclear-energy]-b[heat-exchanger]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "heat-exchanger"
+                }
+            ],
+            "subgroup": "energy",
+            "type": "recipe"
+        },
+        "heat-pipe": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 1,
+            "icon_col": 3,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 20,
+                    "name": "copper-plate"
+                }
+            ],
+            "name": "heat-pipe",
+            "order": "f[nuclear-energy]-c[heat-pipe]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "heat-pipe"
+                }
+            ],
+            "subgroup": "energy",
+            "type": "recipe"
+        },
+        "heavy-armor": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 4,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 100,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 50,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "heavy-armor",
+            "order": "b[heavy-armor]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "heavy-armor"
+                }
+            ],
+            "subgroup": "armor",
+            "type": "recipe"
+        },
+        "heavy-oil-cracking": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.027,
+                    "r": 0.29
+                },
+                "secondary": {
+                    "a": 0,
+                    "b": 0.19,
+                    "g": 0.465,
+                    "r": 0.722
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.365,
+                    "r": 0.87
+                }
+            },
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 6,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 30,
+                    "name": "water",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 40,
+                    "name": "heavy-oil",
+                    "type": "fluid"
+                }
+            ],
+            "main_product": "",
+            "name": "heavy-oil-cracking",
+            "order": "b[fluid-chemistry]-a[heavy-oil-cracking]",
+            "results": [
+                {
+                    "amount": 30,
+                    "name": "light-oil",
+                    "type": "fluid"
+                }
+            ],
+            "subgroup": "fluid-recipes",
+            "type": "recipe"
+        },
+        "high-tech-science-pack": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 14,
+            "icon_col": 7,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "battery"
+                },
+                {
+                    "amount": 3,
+                    "name": "processing-unit"
+                },
+                {
+                    "amount": 1,
+                    "name": "speed-module"
+                },
+                {
+                    "amount": 30,
+                    "name": "copper-cable"
+                }
+            ],
+            "name": "high-tech-science-pack",
+            "order": "f[high-tech-science-pack]",
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "high-tech-science-pack"
+                }
+            ],
+            "subgroup": "science-pack",
+            "type": "recipe"
+        },
+        "inserter": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 8,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "inserter",
+            "order": "b[inserter]",
+            "requester_paste_multiplier": 15,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "inserter"
+                }
+            ],
+            "subgroup": "inserter",
+            "type": "recipe"
+        },
+        "iron-axe": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 9,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "iron-stick"
+                },
+                {
+                    "amount": 3,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "iron-axe",
+            "order": "a[mining]-a[iron-axe]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "iron-axe"
+                }
+            ],
+            "subgroup": "tool",
+            "type": "recipe"
+        },
+        "iron-chest": {
+            "category": "crafting",
+            "enabled": true,
+            "energy_required": 0.5,
+            "icon_col": 10,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 8,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "iron-chest",
+            "order": "a[items]-b[iron-chest]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "iron-chest"
+                }
+            ],
+            "subgroup": "storage",
+            "type": "recipe"
+        },
+        "iron-gear-wheel": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 11,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "iron-gear-wheel",
+            "order": "c[iron-gear-wheel]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "iron-gear-wheel"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "iron-plate": {
+            "category": "smelting",
+            "energy_required": 3.5,
+            "icon_col": 13,
+            "icon_row": 6,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "iron-ore"
+                }
+            ],
+            "name": "iron-plate",
+            "order": "b[iron-plate]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                }
+            ],
+            "subgroup": "raw-material",
+            "type": "recipe"
+        },
+        "iron-stick": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 0,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "iron-stick",
+            "order": "b[iron-stick]",
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "iron-stick"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "kovarex-enrichment-process": {
+            "allow_decomposition": false,
+            "category": "centrifuging",
+            "enabled": false,
+            "energy_required": 50,
+            "icon_col": 1,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 40,
+                    "name": "uranium-235"
+                },
+                {
+                    "amount": 5,
+                    "name": "uranium-238"
+                }
+            ],
+            "main_product": "",
+            "name": "kovarex-enrichment-process",
+            "order": "r[uranium-processing]-c[kovarex-enrichment-process]",
+            "results": [
+                {
+                    "amount": 41,
+                    "name": "uranium-235"
+                },
+                {
+                    "amount": 2,
+                    "name": "uranium-238"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "lab": {
+            "category": "crafting",
+            "energy_required": 2,
+            "icon_col": 2,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 4,
+                    "name": "transport-belt"
+                }
+            ],
+            "name": "lab",
+            "order": "g[lab]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "lab"
+                }
+            ],
+            "subgroup": "production-machine",
+            "type": "recipe"
+        },
+        "land-mine": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 3,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 2,
+                    "name": "explosives"
+                }
+            ],
+            "name": "land-mine",
+            "order": "f[land-mine]",
+            "results": [
+                {
+                    "amount": 4,
+                    "name": "land-mine"
+                }
+            ],
+            "subgroup": "gun",
+            "type": "recipe"
+        },
+        "landfill": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 4,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "stone"
+                }
+            ],
+            "name": "landfill",
+            "order": "c[landfill]-a[dirt]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "landfill"
+                }
+            ],
+            "subgroup": "terrain",
+            "type": "recipe"
+        },
+        "laser-turret": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 20,
+            "icon_col": 5,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 20,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 12,
+                    "name": "battery"
+                }
+            ],
+            "name": "laser-turret",
+            "order": "b[turret]-b[laser-turret]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "laser-turret"
+                }
+            ],
+            "subgroup": "defensive-structure",
+            "type": "recipe"
+        },
+        "light-armor": {
+            "category": "crafting",
+            "enabled": true,
+            "energy_required": 3,
+            "icon_col": 6,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 40,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "light-armor",
+            "order": "a[light-armor]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "light-armor"
+                }
+            ],
+            "subgroup": "armor",
+            "type": "recipe"
+        },
+        "light-oil-cracking": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.406,
+                    "r": 0.785
+                },
+                "secondary": {
+                    "a": 0,
+                    "b": 0.605,
+                    "g": 0.805,
+                    "r": 0.795
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.551,
+                    "r": 0.835
+                }
+            },
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 8,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 30,
+                    "name": "water",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 30,
+                    "name": "light-oil",
+                    "type": "fluid"
+                }
+            ],
+            "main_product": "",
+            "name": "light-oil-cracking",
+            "order": "b[fluid-chemistry]-b[light-oil-cracking]",
+            "results": [
+                {
+                    "amount": 20,
+                    "name": "petroleum-gas",
+                    "type": "fluid"
+                }
+            ],
+            "subgroup": "fluid-recipes",
+            "type": "recipe"
+        },
+        "loader": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 1,
+            "icon_col": 9,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "inserter"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "transport-belt"
+                }
+            ],
+            "name": "loader",
+            "order": "d[loader]-a[basic-loader]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "loader"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "locomotive": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 4,
+            "icon_col": 1,
+            "icon_row": 3,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "engine-unit"
+                },
+                {
+                    "amount": 10,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 30,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "locomotive",
+            "order": "a[train-system]-f[diesel-locomotive]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "locomotive"
+                }
+            ],
+            "subgroup": "transport",
+            "type": "recipe"
+        },
+        "logistic-chest-active-provider": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 10,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "steel-chest"
+                },
+                {
+                    "amount": 3,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "advanced-circuit"
+                }
+            ],
+            "name": "logistic-chest-active-provider",
+            "order": "b[storage]-c[logistic-chest-active-provider]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "logistic-chest-active-provider"
+                }
+            ],
+            "subgroup": "logistic-network",
+            "type": "recipe"
+        },
+        "logistic-chest-passive-provider": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 11,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "steel-chest"
+                },
+                {
+                    "amount": 3,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "advanced-circuit"
+                }
+            ],
+            "name": "logistic-chest-passive-provider",
+            "order": "b[storage]-c[logistic-chest-passive-provider]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "logistic-chest-passive-provider"
+                }
+            ],
+            "subgroup": "logistic-network",
+            "type": "recipe"
+        },
+        "logistic-chest-requester": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 12,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "steel-chest"
+                },
+                {
+                    "amount": 3,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "advanced-circuit"
+                }
+            ],
+            "name": "logistic-chest-requester",
+            "order": "b[storage]-c[logistic-chest-requester]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "logistic-chest-requester"
+                }
+            ],
+            "subgroup": "logistic-network",
+            "type": "recipe"
+        },
+        "logistic-chest-storage": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 13,
+            "icon_row": 7,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "steel-chest"
+                },
+                {
+                    "amount": 3,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "advanced-circuit"
+                }
+            ],
+            "name": "logistic-chest-storage",
+            "order": "b[storage]-c[logistic-chest-storage]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "logistic-chest-storage"
+                }
+            ],
+            "subgroup": "logistic-network",
+            "type": "recipe"
+        },
+        "logistic-robot": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 0,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "flying-robot-frame"
+                },
+                {
+                    "amount": 2,
+                    "name": "advanced-circuit"
+                }
+            ],
+            "name": "logistic-robot",
+            "order": "a[robot]-a[logistic-robot]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "logistic-robot"
+                }
+            ],
+            "subgroup": "logistic-network",
+            "type": "recipe"
+        },
+        "long-handed-inserter": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 1,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 1,
+                    "name": "inserter"
+                }
+            ],
+            "name": "long-handed-inserter",
+            "order": "c[long-handed-inserter]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "long-handed-inserter"
+                }
+            ],
+            "subgroup": "inserter",
+            "type": "recipe"
+        },
+        "low-density-structure": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 30,
+            "icon_col": 8,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "plastic-bar"
+                }
+            ],
+            "name": "low-density-structure",
+            "order": "m[rocket-structure]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "low-density-structure"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "lubricant": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0.01,
+                    "g": 0.26,
+                    "r": 0
+                },
+                "secondary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.64,
+                    "r": 0.071
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.52,
+                    "r": 0.026
+                }
+            },
+            "enabled": false,
+            "energy_required": 1,
+            "icon_col": 2,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "heavy-oil",
+                    "type": "fluid"
+                }
+            ],
+            "name": "lubricant",
+            "order": "e[lubricant]",
+            "results": [
+                {
+                    "amount": 10,
+                    "name": "lubricant",
+                    "type": "fluid"
+                }
+            ],
+            "subgroup": "fluid-recipes",
+            "type": "recipe"
+        },
+        "medium-electric-pole": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 3,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 2,
+                    "name": "copper-plate"
+                }
+            ],
+            "name": "medium-electric-pole",
+            "order": "a[energy]-b[medium-electric-pole]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "medium-electric-pole"
+                }
+            ],
+            "subgroup": "energy-pipe-distribution",
+            "type": "recipe"
+        },
+        "military-science-pack": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 4,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "piercing-rounds-magazine"
+                },
+                {
+                    "amount": 1,
+                    "name": "grenade"
+                },
+                {
+                    "amount": 1,
+                    "name": "gun-turret"
+                }
+            ],
+            "name": "military-science-pack",
+            "order": "d[military-science-pack]",
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "military-science-pack"
+                }
+            ],
+            "subgroup": "science-pack",
+            "type": "recipe"
+        },
+        "modular-armor": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 15,
+            "icon_col": 5,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 30,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 50,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "modular-armor",
+            "order": "c[modular-armor]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "modular-armor"
+                }
+            ],
+            "subgroup": "armor",
+            "type": "recipe"
+        },
+        "night-vision-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 6,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 10,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "night-vision-equipment",
+            "order": "f[night-vision]-a[night-vision-equipment]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "night-vision-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "nuclear-fuel-reprocessing": {
+            "allow_decomposition": false,
+            "category": "centrifuging",
+            "enabled": false,
+            "energy_required": 50,
+            "icon_col": 7,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "used-up-uranium-fuel-cell"
+                }
+            ],
+            "main_product": "",
+            "name": "nuclear-fuel-reprocessing",
+            "order": "r[uranium-processing]-b[nuclear-fuel-reprocessing]",
+            "results": [
+                {
+                    "amount": 3,
+                    "name": "uranium-238"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "nuclear-reactor": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 8,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 500,
+                    "name": "concrete"
+                },
+                {
+                    "amount": 500,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 500,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 500,
+                    "name": "copper-plate"
+                }
+            ],
+            "name": "nuclear-reactor",
+            "order": "f[nuclear-energy]-a[reactor]",
+            "requester_paste_multiplier": 1,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "nuclear-reactor"
+                }
+            ],
+            "subgroup": "energy",
+            "type": "recipe"
+        },
+        "offshore-pump": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 9,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "pipe"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-gear-wheel"
+                }
+            ],
+            "name": "offshore-pump",
+            "order": "b[fluids]-a[offshore-pump]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "offshore-pump"
+                }
+            ],
+            "subgroup": "extraction-machine",
+            "type": "recipe"
+        },
+        "oil-refinery": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 10,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 15,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 10,
+                    "name": "stone-brick"
+                },
+                {
+                    "amount": 10,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 10,
+                    "name": "pipe"
+                }
+            ],
+            "name": "oil-refinery",
+            "order": "d[refinery]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "oil-refinery"
+                }
+            ],
+            "subgroup": "production-machine",
+            "type": "recipe"
+        },
+        "personal-laser-defense-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 11,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "processing-unit"
+                },
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "laser-turret"
+                }
+            ],
+            "name": "personal-laser-defense-equipment",
+            "order": "d[active-defense]-a[personal-laser-defense-equipment]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "personal-laser-defense-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "personal-roboport-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 12,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 40,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 20,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 45,
+                    "name": "battery"
+                }
+            ],
+            "name": "personal-roboport-equipment",
+            "order": "e[robotics]-a[personal-roboport-equipment]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "personal-roboport-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "personal-roboport-mk2-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 20,
+            "icon_col": 13,
+            "icon_row": 8,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "personal-roboport-equipment"
+                },
+                {
+                    "amount": 100,
+                    "name": "processing-unit"
+                }
+            ],
+            "name": "personal-roboport-mk2-equipment",
+            "order": "e[robotics]-b[personal-roboport-mk2-equipment]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "personal-roboport-mk2-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "piercing-rounds-magazine": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 1,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "firearm-magazine"
+                },
+                {
+                    "amount": 1,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "copper-plate"
+                }
+            ],
+            "name": "piercing-rounds-magazine",
+            "order": "a[basic-clips]-b[piercing-rounds-magazine]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "piercing-rounds-magazine"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "piercing-shotgun-shell": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 2,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "shotgun-shell"
+                },
+                {
+                    "amount": 5,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 2,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "piercing-shotgun-shell",
+            "order": "b[shotgun]-b[piercing]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "piercing-shotgun-shell"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "pipe": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 3,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "pipe",
+            "order": "a[pipe]-a[pipe]",
+            "requester_paste_multiplier": 15,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "pipe"
+                }
+            ],
+            "subgroup": "energy-pipe-distribution",
+            "type": "recipe"
+        },
+        "pipe-to-ground": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 4,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "pipe"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "pipe-to-ground",
+            "order": "a[pipe]-b[pipe-to-ground]",
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "pipe-to-ground"
+                }
+            ],
+            "subgroup": "energy-pipe-distribution",
+            "type": "recipe"
+        },
+        "pistol": {
+            "category": "crafting",
+            "energy_required": 5,
+            "icon_col": 5,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "pistol",
+            "order": "a[basic-clips]-a[pistol]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "pistol"
+                }
+            ],
+            "subgroup": "gun",
+            "type": "recipe"
+        },
+        "plastic-bar": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0.498,
+                    "g": 0.498,
+                    "r": 0.498
+                },
+                "secondary": {
+                    "a": 0,
+                    "b": 0.4,
+                    "g": 0.4,
+                    "r": 0.4
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0.305,
+                    "g": 0.305,
+                    "r": 0.305
+                }
+            },
+            "enabled": false,
+            "energy_required": 1,
+            "icon_col": 6,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "petroleum-gas",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 1,
+                    "name": "coal",
+                    "type": "item"
+                }
+            ],
+            "name": "plastic-bar",
+            "order": "g[plastic-bar]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "plastic-bar",
+                    "type": "item"
+                }
+            ],
+            "subgroup": "raw-material",
+            "type": "recipe"
+        },
+        "player-port": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 7,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "player-port",
+            "order": "z[not-used]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "player-port"
+                }
+            ],
+            "subgroup": "defensive-structure",
+            "type": "recipe"
+        },
+        "poison-capsule": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 8,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 3,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 3,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 10,
+                    "name": "coal"
+                }
+            ],
+            "name": "poison-capsule",
+            "order": "b[poison-capsule]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "poison-capsule"
+                }
+            ],
+            "subgroup": "capsule",
+            "type": "recipe"
+        },
+        "power-armor": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 20,
+            "icon_col": 9,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 40,
+                    "name": "processing-unit"
+                },
+                {
+                    "amount": 20,
+                    "name": "electric-engine-unit"
+                },
+                {
+                    "amount": 40,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "power-armor",
+            "order": "d[power-armor]",
+            "requester_paste_multiplier": 1,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "power-armor"
+                }
+            ],
+            "subgroup": "armor",
+            "type": "recipe"
+        },
+        "power-armor-mk2": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 25,
+            "icon_col": 10,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "effectivity-module-3"
+                },
+                {
+                    "amount": 5,
+                    "name": "speed-module-3"
+                },
+                {
+                    "amount": 40,
+                    "name": "processing-unit"
+                },
+                {
+                    "amount": 40,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "power-armor-mk2",
+            "order": "e[power-armor-mk2]",
+            "requester_paste_multiplier": 1,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "power-armor-mk2"
+                }
+            ],
+            "subgroup": "armor",
+            "type": "recipe"
+        },
+        "power-switch": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 2,
+            "icon_col": 11,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "copper-cable"
+                },
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "power-switch",
+            "order": "d[other]-a[power-switch]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "power-switch"
+                }
+            ],
+            "subgroup": "circuit-network",
+            "type": "recipe"
+        },
+        "processing-unit": {
+            "category": "crafting-with-fluid",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 12,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 2,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "sulfuric-acid",
+                    "type": "fluid"
+                }
+            ],
+            "name": "processing-unit",
+            "order": "g[processing-unit]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "processing-unit"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "production-science-pack": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 14,
+            "icon_col": 13,
+            "icon_row": 9,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "electric-engine-unit"
+                },
+                {
+                    "amount": 1,
+                    "name": "electric-furnace"
+                }
+            ],
+            "name": "production-science-pack",
+            "order": "e[production-science-pack]",
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "production-science-pack"
+                }
+            ],
+            "subgroup": "science-pack",
+            "type": "recipe"
+        },
+        "productivity-module": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 15,
+            "icon_col": 0,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "productivity-module",
+            "order": "c[productivity]-a[productivity-module-1]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "productivity-module"
+                }
+            ],
+            "subgroup": "module",
+            "type": "recipe"
+        },
+        "productivity-module-2": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 30,
+            "icon_col": 1,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 4,
+                    "name": "productivity-module"
+                },
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "processing-unit"
+                }
+            ],
+            "name": "productivity-module-2",
+            "order": "c[productivity]-b[productivity-module-2]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "productivity-module-2"
+                }
+            ],
+            "subgroup": "module",
+            "type": "recipe"
+        },
+        "productivity-module-3": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 60,
+            "icon_col": 2,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "productivity-module-2"
+                },
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "processing-unit"
+                }
+            ],
+            "name": "productivity-module-3",
+            "order": "c[productivity]-c[productivity-module-3]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "productivity-module-3"
+                }
+            ],
+            "subgroup": "module",
+            "type": "recipe"
+        },
+        "programmable-speaker": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 2,
+            "icon_col": 3,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "copper-cable"
+                },
+                {
+                    "amount": 4,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "programmable-speaker",
+            "order": "d[other]-b[programmable-speaker]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "programmable-speaker"
+                }
+            ],
+            "subgroup": "circuit-network",
+            "type": "recipe"
+        },
+        "pump": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 2,
+            "icon_col": 4,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "engine-unit"
+                },
+                {
+                    "amount": 1,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 1,
+                    "name": "pipe"
+                }
+            ],
+            "name": "pump",
+            "order": "b[pipe]-c[pump]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "pump"
+                }
+            ],
+            "subgroup": "energy-pipe-distribution",
+            "type": "recipe"
+        },
+        "pumpjack": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 5,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 10,
+                    "name": "pipe"
+                }
+            ],
+            "name": "pumpjack",
+            "order": "b[fluids]-b[pumpjack]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "pumpjack"
+                }
+            ],
+            "subgroup": "extraction-machine",
+            "type": "recipe"
+        },
+        "radar": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 6,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "radar",
+            "order": "d[radar]-a[radar]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "radar"
+                }
+            ],
+            "subgroup": "defensive-structure",
+            "type": "recipe"
+        },
+        "rail": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 7,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "stone"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-stick"
+                },
+                {
+                    "amount": 1,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "rail",
+            "order": "a[train-system]-a[rail]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "rail"
+                }
+            ],
+            "subgroup": "transport",
+            "type": "recipe"
+        },
+        "rail-chain-signal": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 8,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "rail-chain-signal",
+            "order": "a[train-system]-e[rail-signal-chain]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "rail-chain-signal"
+                }
+            ],
+            "subgroup": "transport",
+            "type": "recipe"
+        },
+        "rail-signal": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 9,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "rail-signal",
+            "order": "a[train-system]-d[rail-signal]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "rail-signal"
+                }
+            ],
+            "subgroup": "transport",
+            "type": "recipe"
+        },
+        "railgun": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 10,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 15,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 15,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                }
+            ],
+            "name": "railgun",
+            "order": "c[railgun]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "railgun"
+                }
+            ],
+            "subgroup": "gun",
+            "type": "recipe"
+        },
+        "railgun-dart": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 11,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "railgun-dart",
+            "order": "c[railgun]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "railgun-dart"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "red-wire": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 13,
+            "icon_row": 10,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "copper-cable"
+                }
+            ],
+            "name": "red-wire",
+            "order": "b[wires]-a[red-wire]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "red-wire"
+                }
+            ],
+            "subgroup": "circuit-network",
+            "type": "recipe"
+        },
+        "repair-pack": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 0,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 2,
+                    "name": "iron-gear-wheel"
+                }
+            ],
+            "name": "repair-pack",
+            "order": "b[repair]-a[repair-pack]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "repair-pack"
+                }
+            ],
+            "subgroup": "tool",
+            "type": "recipe"
+        },
+        "roboport": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 1,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 45,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 45,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 45,
+                    "name": "advanced-circuit"
+                }
+            ],
+            "name": "roboport",
+            "order": "c[signal]-a[roboport]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "roboport"
+                }
+            ],
+            "subgroup": "logistic-network",
+            "type": "recipe"
+        },
+        "rocket": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 2,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "explosives"
+                },
+                {
+                    "amount": 2,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "rocket",
+            "order": "d[rocket-launcher]-a[basic]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "rocket"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "rocket-control-unit": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 30,
+            "icon_col": 3,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "processing-unit"
+                },
+                {
+                    "amount": 1,
+                    "name": "speed-module"
+                }
+            ],
+            "name": "rocket-control-unit",
+            "order": "o[rocket-control-unit]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "rocket-control-unit"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "rocket-fuel": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 30,
+            "icon_col": 4,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "solid-fuel"
+                }
+            ],
+            "name": "rocket-fuel",
+            "order": "n[rocket-fuel]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "rocket-fuel"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "rocket-launcher": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 5,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "rocket-launcher",
+            "order": "d[rocket-launcher]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "rocket-launcher"
+                }
+            ],
+            "subgroup": "gun",
+            "type": "recipe"
+        },
+        "rocket-part": {
+            "category": "rocket-building",
+            "enabled": false,
+            "energy_required": 3,
+            "hidden": true,
+            "icon_col": 6,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "low-density-structure"
+                },
+                {
+                    "amount": 10,
+                    "name": "rocket-fuel"
+                },
+                {
+                    "amount": 10,
+                    "name": "rocket-control-unit"
+                }
+            ],
+            "name": "rocket-part",
+            "order": "p[rocket-part]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "rocket-part"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "rocket-silo": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 30,
+            "icon_col": 7,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 1000,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 1000,
+                    "name": "concrete"
+                },
+                {
+                    "amount": 100,
+                    "name": "pipe"
+                },
+                {
+                    "amount": 200,
+                    "name": "processing-unit"
+                },
+                {
+                    "amount": 200,
+                    "name": "electric-engine-unit"
+                }
+            ],
+            "name": "rocket-silo",
+            "order": "e[rocket-silo]",
+            "requester_paste_multiplier": 1,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "rocket-silo"
+                }
+            ],
+            "subgroup": "defensive-structure",
+            "type": "recipe"
+        },
+        "satellite": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 9,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 100,
+                    "name": "low-density-structure"
+                },
+                {
+                    "amount": 100,
+                    "name": "solar-panel"
+                },
+                {
+                    "amount": 100,
+                    "name": "accumulator"
+                },
+                {
+                    "amount": 5,
+                    "name": "radar"
+                },
+                {
+                    "amount": 100,
+                    "name": "processing-unit"
+                },
+                {
+                    "amount": 50,
+                    "name": "rocket-fuel"
+                }
+            ],
+            "name": "satellite",
+            "order": "q[satellite]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "satellite"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "science-pack-1": {
+            "category": "crafting",
+            "energy_required": 5,
+            "icon_col": 10,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-gear-wheel"
+                }
+            ],
+            "name": "science-pack-1",
+            "order": "a[science-pack-1]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "science-pack-1"
+                }
+            ],
+            "subgroup": "science-pack",
+            "type": "recipe"
+        },
+        "science-pack-2": {
+            "category": "crafting",
+            "energy_required": 6,
+            "icon_col": 11,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "inserter"
+                },
+                {
+                    "amount": 1,
+                    "name": "transport-belt"
+                }
+            ],
+            "name": "science-pack-2",
+            "order": "b[science-pack-2]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "science-pack-2"
+                }
+            ],
+            "subgroup": "science-pack",
+            "type": "recipe"
+        },
+        "science-pack-3": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 12,
+            "icon_col": 12,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "engine-unit"
+                },
+                {
+                    "amount": 1,
+                    "name": "electric-mining-drill"
+                }
+            ],
+            "name": "science-pack-3",
+            "order": "c[science-pack-3]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "science-pack-3"
+                }
+            ],
+            "subgroup": "science-pack",
+            "type": "recipe"
+        },
+        "shotgun": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 13,
+            "icon_row": 11,
+            "ingredients": [
+                {
+                    "amount": 15,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 10,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "wood"
+                }
+            ],
+            "name": "shotgun",
+            "order": "b[shotgun]-a[basic]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "shotgun"
+                }
+            ],
+            "subgroup": "gun",
+            "type": "recipe"
+        },
+        "shotgun-shell": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 0,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 2,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "shotgun-shell",
+            "order": "b[shotgun]-a[basic]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "shotgun-shell"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "slowdown-capsule": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 8,
+            "icon_col": 2,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 2,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "coal"
+                }
+            ],
+            "name": "slowdown-capsule",
+            "order": "c[slowdown-capsule]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "slowdown-capsule"
+                }
+            ],
+            "subgroup": "capsule",
+            "type": "recipe"
+        },
+        "small-electric-pole": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 3,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "wood"
+                },
+                {
+                    "amount": 2,
+                    "name": "copper-cable"
+                }
+            ],
+            "name": "small-electric-pole",
+            "order": "a[energy]-a[small-electric-pole]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "small-electric-pole"
+                }
+            ],
+            "subgroup": "energy-pipe-distribution",
+            "type": "recipe"
+        },
+        "small-lamp": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 4,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 3,
+                    "name": "iron-stick"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "small-lamp",
+            "order": "a[light]-a[small-lamp]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "small-lamp"
+                }
+            ],
+            "subgroup": "circuit-network",
+            "type": "recipe"
+        },
+        "small-plane": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 30,
+            "icon_col": 5,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 100,
+                    "name": "plastic-bar"
+                },
+                {
+                    "amount": 200,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 20,
+                    "name": "electric-engine-unit"
+                },
+                {
+                    "amount": 100,
+                    "name": "battery"
+                }
+            ],
+            "name": "small-plane",
+            "order": "b[personal-transport]-c[small-plane]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "small-plane"
+                }
+            ],
+            "subgroup": "transport",
+            "type": "recipe"
+        },
+        "solar-panel": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 6,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 15,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "copper-plate"
+                }
+            ],
+            "name": "solar-panel",
+            "order": "d[solar-panel]-a[solar-panel]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "solar-panel"
+                }
+            ],
+            "subgroup": "energy",
+            "type": "recipe"
+        },
+        "solar-panel-equipment": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 7,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "solar-panel"
+                },
+                {
+                    "amount": 1,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "solar-panel-equipment",
+            "order": "a[energy-source]-a[solar-panel]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "solar-panel-equipment"
+                }
+            ],
+            "subgroup": "equipment",
+            "type": "recipe"
+        },
+        "solid-fuel-from-heavy-oil": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0.095,
+                    "g": 0.095,
+                    "r": 0.16
+                },
+                "secondary": {
+                    "a": 0,
+                    "b": 0.19,
+                    "g": 0.215,
+                    "r": 0.47
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0.135,
+                    "g": 0.144,
+                    "r": 0.435
+                }
+            },
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 9,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "heavy-oil",
+                    "type": "fluid"
+                }
+            ],
+            "name": "solid-fuel-from-heavy-oil",
+            "order": "b[fluid-chemistry]-e[solid-fuel-from-heavy-oil]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "solid-fuel",
+                    "type": "item"
+                }
+            ],
+            "subgroup": "fluid-recipes",
+            "type": "recipe"
+        },
+        "solid-fuel-from-light-oil": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.122,
+                    "r": 0.27
+                },
+                "secondary": {
+                    "a": 0,
+                    "b": 0.325,
+                    "g": 0.546,
+                    "r": 0.735
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.348,
+                    "r": 0.61
+                }
+            },
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 10,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "light-oil",
+                    "type": "fluid"
+                }
+            ],
+            "name": "solid-fuel-from-light-oil",
+            "order": "b[fluid-chemistry]-c[solid-fuel-from-light-oil]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "solid-fuel",
+                    "type": "item"
+                }
+            ],
+            "subgroup": "fluid-recipes",
+            "type": "recipe"
+        },
+        "solid-fuel-from-petroleum-gas": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0.51,
+                    "g": 0.075,
+                    "r": 0.331
+                },
+                "secondary": {
+                    "a": 0.361,
+                    "b": 0.615,
+                    "g": 0.54,
+                    "r": 0.589
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0.695,
+                    "g": 0.145,
+                    "r": 0.469
+                }
+            },
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 11,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "petroleum-gas",
+                    "type": "fluid"
+                }
+            ],
+            "name": "solid-fuel-from-petroleum-gas",
+            "order": "b[fluid-chemistry]-d[solid-fuel-from-petroleum-gas]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "solid-fuel",
+                    "type": "item"
+                }
+            ],
+            "subgroup": "fluid-recipes",
+            "type": "recipe"
+        },
+        "speed-module": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 15,
+            "icon_col": 13,
+            "icon_row": 12,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "speed-module",
+            "order": "a[speed]-a[speed-module-1]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "speed-module"
+                }
+            ],
+            "subgroup": "module",
+            "type": "recipe"
+        },
+        "speed-module-2": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 30,
+            "icon_col": 0,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 4,
+                    "name": "speed-module"
+                },
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "processing-unit"
+                }
+            ],
+            "name": "speed-module-2",
+            "order": "a[speed]-b[speed-module-2]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "speed-module-2"
+                }
+            ],
+            "subgroup": "module",
+            "type": "recipe"
+        },
+        "speed-module-3": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 60,
+            "icon_col": 1,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "speed-module-2"
+                },
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "processing-unit"
+                }
+            ],
+            "name": "speed-module-3",
+            "order": "a[speed]-c[speed-module-3]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "speed-module-3"
+                }
+            ],
+            "subgroup": "module",
+            "type": "recipe"
+        },
+        "splitter": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 1,
+            "icon_col": 2,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 4,
+                    "name": "transport-belt"
+                }
+            ],
+            "name": "splitter",
+            "order": "c[splitter]-a[splitter]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "splitter"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "stack-filter-inserter": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 3,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "stack-inserter"
+                },
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                }
+            ],
+            "name": "stack-filter-inserter",
+            "order": "g[stack-filter-inserter]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "stack-filter-inserter"
+                }
+            ],
+            "subgroup": "inserter",
+            "type": "recipe"
+        },
+        "stack-inserter": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 4,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 15,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 15,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 1,
+                    "name": "fast-inserter"
+                }
+            ],
+            "name": "stack-inserter",
+            "order": "f[stack-inserter]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "stack-inserter"
+                }
+            ],
+            "subgroup": "inserter",
+            "type": "recipe"
+        },
+        "steam-engine": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 6,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 8,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 5,
+                    "name": "pipe"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "steam-engine",
+            "order": "b[steam-power]-b[steam-engine]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "steam-engine"
+                }
+            ],
+            "subgroup": "energy",
+            "type": "recipe"
+        },
+        "steam-turbine": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 7,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 50,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 50,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 20,
+                    "name": "pipe"
+                }
+            ],
+            "name": "steam-turbine",
+            "order": "b[steam-power]-c[steam-turbine]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "steam-turbine"
+                }
+            ],
+            "subgroup": "energy",
+            "type": "recipe"
+        },
+        "steel-axe": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 8,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 2,
+                    "name": "iron-stick"
+                }
+            ],
+            "name": "steel-axe",
+            "order": "a[mining]-b[steel-axe]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "steel-axe"
+                }
+            ],
+            "subgroup": "tool",
+            "type": "recipe"
+        },
+        "steel-chest": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 9,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 8,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "steel-chest",
+            "order": "a[items]-c[steel-chest]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "steel-chest"
+                }
+            ],
+            "subgroup": "storage",
+            "type": "recipe"
+        },
+        "steel-furnace": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 10,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 6,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "stone-brick"
+                }
+            ],
+            "name": "steel-furnace",
+            "order": "b[steel-furnace]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "steel-furnace"
+                }
+            ],
+            "subgroup": "smelting-machine",
+            "type": "recipe"
+        },
+        "steel-plate": {
+            "category": "smelting",
+            "enabled": false,
+            "energy_required": 17.5,
+            "icon_col": 11,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "steel-plate",
+            "order": "d[steel-plate]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "steel-plate"
+                }
+            ],
+            "subgroup": "raw-material",
+            "type": "recipe"
+        },
+        "stone-brick": {
+            "category": "smelting",
+            "enabled": true,
+            "energy_required": 3.5,
+            "icon_col": 13,
+            "icon_row": 13,
+            "ingredients": [
+                {
+                    "amount": 2,
+                    "name": "stone"
+                }
+            ],
+            "name": "stone-brick",
+            "order": "a[stone-brick]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "stone-brick"
+                }
+            ],
+            "subgroup": "terrain",
+            "type": "recipe"
+        },
+        "stone-furnace": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 0,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "stone"
+                }
+            ],
+            "name": "stone-furnace",
+            "order": "a[stone-furnace]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "stone-furnace"
+                }
+            ],
+            "subgroup": "smelting-machine",
+            "type": "recipe"
+        },
+        "stone-wall": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 1,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "stone-brick"
+                }
+            ],
+            "name": "stone-wall",
+            "order": "a[stone-wall]-a[stone-wall]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "stone-wall"
+                }
+            ],
+            "subgroup": "defensive-structure",
+            "type": "recipe"
+        },
+        "storage-tank": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 3,
+            "icon_col": 2,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 20,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "storage-tank",
+            "order": "b[fluid]-a[storage-tank]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "storage-tank"
+                }
+            ],
+            "subgroup": "storage",
+            "type": "recipe"
+        },
+        "submachine-gun": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 3,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 5,
+                    "name": "copper-plate"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-plate"
+                }
+            ],
+            "name": "submachine-gun",
+            "order": "a[basic-clips]-b[submachine-gun]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "submachine-gun"
+                }
+            ],
+            "subgroup": "gun",
+            "type": "recipe"
+        },
+        "substation": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 4,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "advanced-circuit"
+                },
+                {
+                    "amount": 5,
+                    "name": "copper-plate"
+                }
+            ],
+            "name": "substation",
+            "order": "a[energy]-d[substation]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "substation"
+                }
+            ],
+            "subgroup": "energy-pipe-distribution",
+            "type": "recipe"
+        },
+        "sulfur": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.659,
+                    "r": 1
+                },
+                "secondary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 1,
+                    "r": 0.812
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.806,
+                    "r": 0.96
+                }
+            },
+            "enabled": false,
+            "energy_required": 1,
+            "icon_col": 5,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 30,
+                    "name": "water",
+                    "type": "fluid"
+                },
+                {
+                    "amount": 30,
+                    "name": "petroleum-gas",
+                    "type": "fluid"
+                }
+            ],
+            "name": "sulfur",
+            "order": "f[sulfur]",
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "sulfur",
+                    "type": "item"
+                }
+            ],
+            "subgroup": "raw-material",
+            "type": "recipe"
+        },
+        "sulfuric-acid": {
+            "category": "chemistry",
+            "crafting_machine_tint": {
+                "primary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.735,
+                    "r": 0.875
+                },
+                "secondary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.94,
+                    "r": 0.103
+                },
+                "tertiary": {
+                    "a": 0,
+                    "b": 0,
+                    "g": 0.795,
+                    "r": 0.564
+                }
+            },
+            "enabled": false,
+            "energy_required": 1,
+            "icon_col": 6,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "sulfur",
+                    "type": "item"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-plate",
+                    "type": "item"
+                },
+                {
+                    "amount": 100,
+                    "name": "water",
+                    "type": "fluid"
+                }
+            ],
+            "name": "sulfuric-acid",
+            "order": "a[fluid]-f[sulfuric-acid]",
+            "results": [
+                {
+                    "amount": 50,
+                    "name": "sulfuric-acid",
+                    "type": "fluid"
+                }
+            ],
+            "subgroup": "fluid-recipes",
+            "type": "recipe"
+        },
+        "tank": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 5,
+            "icon_col": 7,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 32,
+                    "name": "engine-unit"
+                },
+                {
+                    "amount": 50,
+                    "name": "steel-plate"
+                },
+                {
+                    "amount": 15,
+                    "name": "iron-gear-wheel"
+                },
+                {
+                    "amount": 10,
+                    "name": "advanced-circuit"
+                }
+            ],
+            "name": "tank",
+            "order": "b[personal-transport]-b[tank]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "tank"
+                }
+            ],
+            "subgroup": "transport",
+            "type": "recipe"
+        },
+        "train-stop": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 0.5,
+            "icon_col": 9,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 5,
+                    "name": "electronic-circuit"
+                },
+                {
+                    "amount": 10,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 3,
+                    "name": "steel-plate"
+                }
+            ],
+            "name": "train-stop",
+            "order": "a[train-system]-c[train-stop]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "train-stop"
+                }
+            ],
+            "subgroup": "transport",
+            "type": "recipe"
+        },
+        "transport-belt": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 10,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 1,
+                    "name": "iron-gear-wheel"
+                }
+            ],
+            "name": "transport-belt",
+            "order": "a[transport-belt]-a[transport-belt]",
+            "requester_paste_multiplier": 20,
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "transport-belt"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "underground-belt": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 1,
+            "icon_col": 11,
+            "icon_row": 14,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 5,
+                    "name": "transport-belt"
+                }
+            ],
+            "name": "underground-belt",
+            "order": "b[underground-belt]-a[underground-belt]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "underground-belt"
+                }
+            ],
+            "subgroup": "belt",
+            "type": "recipe"
+        },
+        "uranium-cannon-shell": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 12,
+            "icon_col": 0,
+            "icon_row": 15,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "cannon-shell"
+                },
+                {
+                    "amount": 1,
+                    "name": "uranium-238"
+                }
+            ],
+            "name": "uranium-cannon-shell",
+            "order": "d[cannon-shell]-c[uranium]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "uranium-cannon-shell"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "uranium-fuel-cell": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 1,
+            "icon_row": 15,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "iron-plate"
+                },
+                {
+                    "amount": 1,
+                    "name": "uranium-235"
+                },
+                {
+                    "amount": 19,
+                    "name": "uranium-238"
+                }
+            ],
+            "name": "uranium-fuel-cell",
+            "order": "r[uranium-processing]-a[uranium-fuel-cell]",
+            "results": [
+                {
+                    "amount": 10,
+                    "name": "uranium-fuel-cell"
+                }
+            ],
+            "subgroup": "intermediate-product",
+            "type": "recipe"
+        },
+        "uranium-processing": {
+            "category": "centrifuging",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 3,
+            "icon_row": 15,
+            "ingredients": [
+                {
+                    "amount": 10,
+                    "name": "uranium-ore"
+                }
+            ],
+            "name": "uranium-processing",
+            "order": "h[uranium-processing]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "uranium-235",
+                    "probability": 0.007
+                },
+                {
+                    "amount": 1,
+                    "name": "uranium-238",
+                    "probability": 0.993
+                }
+            ],
+            "subgroup": "raw-material",
+            "type": "recipe"
+        },
+        "uranium-rounds-magazine": {
+            "category": "crafting",
+            "enabled": false,
+            "energy_required": 10,
+            "icon_col": 4,
+            "icon_row": 15,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "piercing-rounds-magazine"
+                },
+                {
+                    "amount": 1,
+                    "name": "uranium-238"
+                }
+            ],
+            "name": "uranium-rounds-magazine",
+            "order": "a[basic-clips]-c[uranium-rounds-magazine]",
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "uranium-rounds-magazine"
+                }
+            ],
+            "subgroup": "ammo",
+            "type": "recipe"
+        },
+        "wood": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 7,
+            "icon_row": 15,
+            "ingredients": [
+                {
+                    "amount": 1,
+                    "name": "raw-wood"
+                }
+            ],
+            "name": "wood",
+            "order": "a[wood]",
+            "results": [
+                {
+                    "amount": 2,
+                    "name": "wood"
+                }
+            ],
+            "subgroup": "raw-material",
+            "type": "recipe"
+        },
+        "wooden-chest": {
+            "category": "crafting",
+            "energy_required": 0.5,
+            "icon_col": 8,
+            "icon_row": 15,
+            "ingredients": [
+                {
+                    "amount": 4,
+                    "name": "wood"
+                }
+            ],
+            "name": "wooden-chest",
+            "order": "a[items]-a[wooden-chest]",
+            "requester_paste_multiplier": 4,
+            "results": [
+                {
+                    "amount": 1,
+                    "name": "wooden-chest"
+                }
+            ],
+            "subgroup": "storage",
+            "type": "recipe"
+        }
+    },
+    "resource": {
+        "coal": {
+            "icon_col": 12,
+            "icon_row": 1,
+            "minable": {
+                "hardness": 0.9,
+                "mining_particle": "coal-particle",
+                "mining_time": 2,
+                "results": [
+                    {
+                        "amount": 1,
+                        "name": "coal"
+                    }
+                ]
+            },
+            "name": "coal"
+        },
+        "copper-ore": {
+            "icon_col": 7,
+            "icon_row": 2,
+            "minable": {
+                "hardness": 0.9,
+                "mining_particle": "copper-ore-particle",
+                "mining_time": 2,
+                "results": [
+                    {
+                        "amount": 1,
+                        "name": "copper-ore"
+                    }
+                ]
+            },
+            "name": "copper-ore"
+        },
+        "crude-oil": {
+            "category": "basic-fluid",
+            "icon_col": 9,
+            "icon_row": 2,
+            "minable": {
+                "hardness": 1,
+                "mining_time": 1,
+                "results": [
+                    {
+                        "amount_max": 10,
+                        "amount_min": 10,
+                        "name": "crude-oil",
+                        "probability": 1,
+                        "type": "fluid"
+                    }
+                ]
+            },
+            "name": "crude-oil"
+        },
+        "iron-ore": {
+            "icon_col": 12,
+            "icon_row": 6,
+            "minable": {
+                "hardness": 0.9,
+                "mining_particle": "iron-ore-particle",
+                "mining_time": 2,
+                "results": [
+                    {
+                        "amount": 1,
+                        "name": "iron-ore"
+                    }
+                ]
+            },
+            "name": "iron-ore"
+        },
+        "stone": {
+            "icon_col": 12,
+            "icon_row": 13,
+            "minable": {
+                "hardness": 0.4,
+                "mining_particle": "stone-particle",
+                "mining_time": 2,
+                "results": [
+                    {
+                        "amount": 1,
+                        "name": "stone"
+                    }
+                ]
+            },
+            "name": "stone"
+        },
+        "uranium-ore": {
+            "icon_col": 2,
+            "icon_row": 15,
+            "minable": {
+                "fluid_amount": 10,
+                "hardness": 0.9,
+                "mining_particle": "stone-particle",
+                "mining_time": 4,
+                "required_fluid": "sulfuric-acid",
+                "results": [
+                    {
+                        "amount": 1,
+                        "name": "uranium-ore"
+                    }
+                ]
+            },
+            "name": "uranium-ore"
+        }
+    },
+    "rocket-silo": {
+        "rocket-silo": {
+            "active_energy_usage": "3990KW",
+            "allowed_effects": [
+                "consumption",
+                "speed",
+                "productivity",
+                "pollution"
+            ],
+            "crafting_categories": [
+                "rocket-building"
+            ],
+            "crafting_speed": 1,
+            "energy_usage": 250000.0,
+            "icon_col": 7,
+            "icon_row": 11,
+            "idle_energy_usage": "10KW",
+            "lamp_energy_usage": "10KW",
+            "module_slots": 4,
+            "name": "rocket-silo",
+            "rocket_parts_required": 100
+        }
+    },
+    "solar-panel": {
+        "solar-panel": {
+            "icon_col": 6,
+            "icon_row": 12,
+            "name": "solar-panel",
+            "production": "60kW"
+        }
+    },
+    "sprites": {
+        "extra": {
+            "slot_icon_module": {
+                "icon_col": 1,
+                "icon_row": 12,
+                "name": "no module"
+            }
+        },
+        "hash": "2104aa89e14cbd861ac5865881725835"
+    }
+}

--- a/settings.js
+++ b/settings.js
@@ -9,6 +9,7 @@ function Modification(name, filename) {
 var MODIFICATIONS = {
     "0-15-35": new Modification("Vanilla 0.15.35", "vanilla-0.15.35.json"),
     "0-15-35x": new Modification("Vanilla 0.15.35 - Expensive", "vanilla-0.15.35-expensive.json"),
+    "0-16-1": new Modification("Vanilla 0.16.1", "vanilla-0.16.1.json"),
     //"bobs-0-15-35": new Modification("Bob's Mods + base 0.15.35", "bobs-0.15.35.json")
 }
 


### PR DESCRIPTION
0.16.1 Changes
    fast-underground 0.5>2s
    express-underground 0.5>2s
    locomotive 0.5>4
    cargo-wagon 0.5>1
    car 0.5>2
    tank 0.5>5
    roboport 10>5
    nuclear-reactor 4>8
    heat-exchanger 0.5>3
    heat-pipe 0.5>1
    oil-refinery 10>8
    lab 3>2
    explosives now craft x2
    satellite 3>5
    production science no longer needs assem 1

Still needed:
All the new items: Cliff Explosives, Nuclear Fuel, Artillery (wagon turret shell targeting-remote)