### PR TITLE
Improve speed of pivot

### DIFF
--- a/factory.js
+++ b/factory.js
@@ -206,7 +206,7 @@ Factory.prototype = {
         return {"fuel": "electric", "power": power}
     },
     recipeRate: function(spec, recipe) {
-        return one.div(recipe.time).mul(this.factory.speed).mul(this.speedEffect(spec))
+        return recipe.time.reciprocate().mul(this.factory.speed).mul(this.speedEffect(spec))
     },
     copyModules: function(other, recipe) {
         var length = Math.max(this.modules.length, other.modules.length)

--- a/rational.js
+++ b/rational.js
@@ -146,6 +146,9 @@ Rational.prototype = {
         var mod = this.sub(other.mul(div))
         return {quotient: div, remainder: mod}
     },
+    reciprocate: function () {
+        return new Rational(this.q, this.p)
+    },
 }
 
 function RationalFromString(s) {

--- a/simplex.js
+++ b/simplex.js
@@ -2,7 +2,7 @@
 
 function pivot(A, row, col) {
     var x = A.index(row, col)
-    A.mulRow(row, one.div(x))
+    A.mulRow(row, x.reciprocate())
     for (var r = 0; r < A.rows; r++) {
         if (r === row) {
             continue


### PR DESCRIPTION
Avoiding unnecessary math in `pivot` improves runtime dramatically for me, though this is an older change and I don't have any numbers to share.

Adding `Rational#reciprocate` doesn't help nearly as much, but `pivot` is very intensive and every little bit helps.

This should help with #35