### PR TITLE
Fix tooltip getting stuck open in Firefox

### DIFF
--- a/display.js
+++ b/display.js
@@ -956,6 +956,15 @@ RecipeTable.prototype = {
                 // Don't rearrange the DOM if we don't need to.
                 if (!sameRows) {
                     row.appendTo(this.node)
+                    // Some browsers don't trigger mouseleave here...
+                    var evtMouseLeave = new MouseEvent("mouseleave", { view: window, bubbles: true, cancelable: true })
+                    if (row.itemRow) {
+                        row.itemRow.image.dispatchEvent(evtMouseLeave);
+                    } else if (row.itemRows) {
+                        for (var j = 0; j < row.itemRows.length; j++) {
+                            row.itemRows[j].image.dispatchEvent(evtMouseLeave);
+                        }
+                    }
                 }
                 row.setRates(totals, items)
             } else {


### PR DESCRIPTION
In firefox and edge (not chrome), the fancy tooltips can get stuck open
while ignoring an item if ignoring that item causes it to reorder the
ingredients such that the reordered item is no longer under the cursor.

This seems to be caused by the 'mouseleave' event only being triggered
if the mouse is moved away from the item in these browsers (not the item
being moved away from the mouse). The solution AFAIK is to manually
trigger the 'mouseleave' event on icons for rows changing order.

Tested under firefox v68.0.1, chrome 75, and edge 42.17134 under Win10.

Repro steps:
  1. Open in firefox
  2. Load the yellow science recipe
  3. Click the icon for green circuits, keeping the mosue still (ie.
     ignore it)
  4. Observe that the green circuit tooltip remains open.