### PR TITLE
Added belt precision

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -214,6 +214,10 @@ limitations under the License.-->
         <td class="setting-label">Factory precision:</td>
         <td><input id="fprec" class="prec" type="number" value="1" min="0" onchange="changeFPrec(event)"></td>
         </tr>
+		<tr>
+        <td class="setting-label">Belt precision:</td>
+        <td><input id="bprec" class="prec" type="number" value="1" min="0" onchange="changeBPrec(event)"></td>
+        </tr>
 
         <tr>
         <td class="setting-label">Minimum assembling machine level:</td>

--- a/display.js
+++ b/display.js
@@ -35,6 +35,14 @@ function displayCount(x) {
     }
 }
 
+function displayBelt(x) {
+    if (displayFormat == "rational") {
+        return x.toMixed()
+    } else {
+        return x.toUpDecimal(beltPrecision)
+    }
+}
+
 function align(s, prec) {
     if (displayFormat == "rational") {
         return s
@@ -60,6 +68,10 @@ function alignRate(x) {
 
 function alignCount(x) {
     return align(displayCount(x), countPrecision)
+}
+
+function alignBelt(x) {
+    return align(displayBelt(x), beltPrecision)
 }
 
 var powerSuffixes = ["\u00A0W", "kW", "MW", "GW", "TW", "PW"]
@@ -262,7 +274,7 @@ ItemRow.prototype = {
         this.beltCell.appendChild(beltImage)
         this.beltCell.appendChild(new Text(" \u00d7"))
         var beltCount = itemRate.div(preferredBeltSpeed)
-        this.beltCountNode.textContent = alignCount(beltCount)
+        this.beltCountNode.textContent = alignBelt(beltCount)
     },
     setPipe: function(itemRate) {
         // 0.17 changes these fluid calculations, but the new model is not yet

--- a/events.js
+++ b/events.js
@@ -164,6 +164,11 @@ function changeFPrec(event) {
     display()
 }
 
+function changeBPrec(event) {
+    beltPrecision = Number(event.target.value)
+    display()
+}
+
 // Triggered when the "minimum assembling machine" setting is changed.
 function changeMin(min) {
     setMinimumAssembler(min)

--- a/settings.js
+++ b/settings.js
@@ -174,6 +174,9 @@ var ratePrecision = DEFAULT_RATE_PRECISION
 var DEFAULT_COUNT_PRECISION = 1
 var countPrecision = DEFAULT_COUNT_PRECISION
 
+var DEFAULT_BELT_PRECISION = 1
+var beltPrecision = DEFAULT_BELT_PRECISION
+
 function renderPrecisions(settings) {
     ratePrecision = DEFAULT_RATE_PRECISION
     if ("rp" in settings) {
@@ -185,6 +188,11 @@ function renderPrecisions(settings) {
         countPrecision = Number(settings.cp)
     }
     document.getElementById("fprec").value = countPrecision
+	beltPrecision = DEFAULT_BELT_PRECISION
+    if ("bp" in settings) {
+        beltPrecision = Number(settings.bp)
+    }
+    document.getElementById("bprec").value = beltPrecision
 }
 
 // minimum assembler

--- a/steps.js
+++ b/steps.js
@@ -168,7 +168,7 @@ function displaySteps(items, order, totals) {
                 var beltRateCell = document.createElement("td")
                 beltRateCell.classList.add("right-align")
                 tt = document.createElement("tt")
-                tt.textContent = alignCount(belts)
+                tt.textContent = alignBelt(belts)
                 beltRateCell.append(tt)
                 row.appendChild(beltRateCell)
             }


### PR DESCRIPTION
Added a setting to allow belt precision to be set separately from factory precision.
Duplicated the existing parts of the code related to Count Precision and renamed them for the new setting.
I find it is useful for factories I always round up to the nearest whole to satisfy demand and so set the precision to 0 but it's also useful to know when planning belts if a whole belt is needed or just half a belt is required and so can use a precision of 1 to enable that information to be displayed simultaneously