### PR TITLE
Update to 0.17.60 as default version

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -30,7 +30,7 @@ var MODIFICATIONS = {
     "bobs-0-16-51": new Modification("(EXPERIMENTAL) Bob's Mods + base 0.16.51", "bobs-0.16.51.json", true, [800, 832])
 }
 
-var DEFAULT_MODIFICATION = "0-16-51"
+var DEFAULT_MODIFICATION = "0-17-60"
 
 function addOverrideOptions(version) {
     var tag = "local-" + version.replace(/\./g, "-")


### PR DESCRIPTION
This is now the stable release. Recipes are the same as .72 but I didn't want to complicate things by changing more than I had to. 