### PR TITLE
23-Aug-2020: Rocket launch animation tick count align with wiki

### DIFF
--- a/factory.js
+++ b/factory.js
@@ -275,7 +275,8 @@ Miner.prototype.prodEffect = function(spec) {
     return prod.add(spec.miningProd)
 }
 
-var rocketLaunchDuration = RationalFromFloats(2475, 60)
+// Duration is recorded as 2420 ticks in official wiki https://wiki.factorio.com/Rocket_silo#Maximum_throughput
+var rocketLaunchDuration = RationalFromFloats(2420, 60)
 
 function launchRate(spec) {
     var partRecipe = solver.recipes["rocket-part"]


### PR DESCRIPTION
https://wiki.factorio.com/Rocket_silo#Maximum_throughput records rocket animation as 2420. Code is using 2475.

With this code change, using 2420 ticks, a silo with 4 prod 3 modules and 20 beacons (40 Speed 3 modules) will produce 984 space science per minute, as stated in wiki.