### PR TITLE
Ui optimizations

### DIFF
--- a/icon.js
+++ b/icon.js
@@ -18,26 +18,34 @@ var PX_HEIGHT = 32
 
 var sheet_hash
 
+var images_buffer = new Map()
+
 function Sprite(name, col, row) {
     this.name = name
     this.icon_col = col
     this.icon_row = row
-}
+}   
 
 function getImage(obj, suppressTooltip, tooltipTarget) {
-    var im = blankImage()
-    im.classList.add("icon")
-    var x = -obj.icon_col * PX_WIDTH
-    var y = -obj.icon_row * PX_HEIGHT
-    im.style.setProperty("background", "url(images/sprite-sheet-" + sheet_hash + ".png)")
-    im.style.setProperty("background-position", x + "px " + y + "px")
-    if (tooltipsEnabled && obj.renderTooltip && !suppressTooltip) {
-        addTooltip(im, obj, tooltipTarget)
+    if (images_buffer.has(obj.name)) {
+        return images_buffer.get(obj.name)
     } else {
-        im.title = obj.name
+        var im = blankImage()
+        im.classList.add("icon")
+        var x = -obj.icon_col * PX_WIDTH
+        var y = -obj.icon_row * PX_HEIGHT
+        im.style.setProperty("background", "url(images/sprite-sheet-" + sheet_hash + ".png)")
+        im.style.setProperty("background-position", x + "px " + y + "px")
+        if (tooltipsEnabled && obj.renderTooltip && !suppressTooltip) {
+            addTooltip(im, obj, tooltipTarget)
+        } else {
+            im.title = obj.name
+        }
+        im.alt = obj.name
+        images_buffer[obj.name] = im
+        return im
     }
-    im.alt = obj.name
-    return im
+    
 }
 
 function addTooltip(im, obj, target) {

--- a/icon.js
+++ b/icon.js
@@ -41,8 +41,7 @@ function getImage(obj, suppressTooltip, tooltipTarget) {
 }
 
 function addTooltip(im, obj, target) {
-    var node = obj.renderTooltip()
-    return new Tooltip(im, node, target)
+    return new Tooltip(im, obj, target)
 }
 
 function blankImage() {

--- a/tooltip.js
+++ b/tooltip.js
@@ -73,7 +73,7 @@ Tooltip.prototype = {
     create: function() {
         var node = document.createElement("div")
         node.classList.add("tooltip")
-        node.appendChild(this.content)
+        node.appendChild(this.content.renderTooltip())
         return node
     },
     addEventListeners: function() {


### PR DESCRIPTION
Hello, 

This attempts to speed up the interface showing up when new recipe lines are added.
- The first commit delay rendering of the tooltips until mouseover
- The second commit caches the call to getImage for each ingredient

In my test case (vanilla factorio, 61 white science per minute, press + to add 5 red circuit/min, then remove those 5 red circuit/min), there is an improvement when the tooltips are enabled: 
- adding red circuits : 2.20s in the parent commit, 0.87s after these
- removing red circuits : 0.93s in the parent commit, 0.72s after 

(averaged on 4 measures each in firefox 80.0 win64)