### PR TITLE
Select chemical plant when more than 1

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -226,6 +226,11 @@ limitations under the License.-->
         </tr>
 
         <tr>
+        <td class="setting-label">Preferred chemical plant:</td>
+        <td><span id="chemical_plant"></span></td>
+        </tr>
+
+        <tr>
         <td class="setting-label">Preferred fuel:</td>
         <td><span id="fuel"></span></td>
         </tr>

--- a/events.js
+++ b/events.js
@@ -177,6 +177,13 @@ function changeFurnace(furnace) {
     itemUpdate()
 }
 
+// Triggered when the chemical plant is changed.
+function changeChemicalPlant(chemPlant) {
+    spec.setChemicalPlant(chemPlant.name)
+    solver.findSubgraphs(spec)
+    itemUpdate()
+}
+
 // Triggered when the preferred fuel is changed.
 function changeFuel(fuel) {
     setPreferredFuel(fuel.name)

--- a/factory.js
+++ b/factory.js
@@ -345,6 +345,9 @@ function FactorySpec(factories) {
     var smelters = this.factories["smelting"]
     this.furnace = smelters[smelters.length - 1]
     DEFAULT_FURNACE = this.furnace.name
+    let chem_plants = this.factories["chemistry"]
+    this.chemical_plant = chem_plants[0]
+    DEFAULT_CHEM_PLANT = this.chemical_plant.name
     this.miningProd = zero
     this.ignore = {}
 
@@ -375,9 +378,24 @@ FactorySpec.prototype = {
     useFurnace: function(recipe) {
         return recipe.category == "smelting"
     },
+    setChemicalPlant: function(name) {
+        let chemPlants = this.factories["chemistry"]
+        for (var i = 0; i < chemPlants.length; i++) {
+            if (chemPlants[i].name == name) {
+                this.chemical_plant = chemPlants[i]
+                return
+            }
+        }
+    },
+    useChemicalPlant: function(recipe) {
+        return recipe.category == "chemistry"
+    },
     getFactoryDef: function(recipe) {
         if (this.useFurnace(recipe)) {
             return this.furnace
+        }
+        if (this.useChemicalPlant(recipe)) {
+            return this.chemical_plant
         }
         var factories = this.factories[recipe.category]
         if (!factories) {

--- a/settings.js
+++ b/settings.js
@@ -251,6 +251,44 @@ function renderFurnace(settings) {
     cell.replaceChild(node, oldNode)
 }
 
+// chemical plant
+
+// Assigned during FactorySpec initialization.
+var DEFAULT_CHEM_PLANT
+
+function renderChemicalPlant(settings) {
+    let chemPlantName = DEFAULT_CHEM_PLANT
+    if ("chemicalPlant" in settings) {
+        chemPlantName = settings.chemical_plant
+    }
+    if (chemPlantName !== spec.chemical_plant.name) {
+        spec.setChemicalPlant(chemPlantName)
+    }
+    let oldNode = document.getElementById("chemical_plant")
+
+    if (spec.factories["chemistry"].length < 2) {
+        //Nothing to choose, so kill the node
+        oldNode.parentElement.parentElement.hidden = "hidden"
+    } else {
+        oldNode.parentElement.parentElement.hidden = ""
+    }
+
+    let cell = oldNode.parentNode
+    let node = document.createElement("span")
+    node.id = "chemical_plant"
+    let chemPlants = spec.factories["chemistry"]
+    let dropdown = makeDropdown(d3.select(node))
+    let inputs = dropdown.selectAll("div").data(chemPlants).join("div")
+    let labels = addInputs(
+        inputs,
+        "chemical_plant_dropdown",
+        d => d.name === chemPlantName,
+        changeChemicalPlant,
+    )
+    labels.append(d => getImage(d, false, dropdown.node()))
+    cell.replaceChild(node, oldNode)
+}
+
 // fuel
 var DEFAULT_FUEL = "coal"
 
@@ -600,6 +638,7 @@ function renderSettings(settings) {
     renderPrecisions(settings)
     renderMinimumAssembler(settings)
     renderFurnace(settings)
+    renderChemicalPlant(settings)
     renderFuel(settings)
     renderOil(settings)
     renderKovarex(settings)


### PR DESCRIPTION
Added an option to select the default chemical plant when there's more than one. If there's one (or fewer), the option is hidden and the first chemical plant is the default. This change is mostly useful for mods as vanilla only has one chemical plant, but it was carefully done so that it is not a breaking change for vanilla data sets.