### PR TITLE
Add visualizer alignment option

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -158,6 +158,25 @@ limitations under the License.-->
                         <label for="visdir_down">Vertical</label>
                     </div>
 
+                    <div class="setting-label top">Alignment:</div>
+                    <div>
+                        <input
+                            type="radio"
+                            name="alignment-direction"
+                            id="alignment_right"
+                            value="right"
+                            checked
+                            onchange="changeVisualizerAlignment(event)">
+                        <label for="alignment_right">Right</label><br />
+                        <input
+                            type="radio"
+                            name="alignment-direction"
+                            id="alignment_left"
+                            value="left"
+                            onchange="changeVisualizerAlignment(event)">
+                        <label for="alignment_left">Left</label>
+                    </div>
+
                     <div class="setting-label middle">Maximum node breadth:</div>
                     <div>
                         <input

--- a/events.js
+++ b/events.js
@@ -258,6 +258,12 @@ function changeVisualizerDirection(event) {
     display()
 }
 
+// Triggered when the visualizer alignment is changed.
+function changeVisualizerAlignment(event) {
+    visAlignment = event.target.value
+    display()
+}
+
 // Triggered when the max node breadth is changed.
 function changeNodeBreadth(event) {
     maxNodeHeight = Number(event.target.value)

--- a/fragment.js
+++ b/fragment.js
@@ -76,6 +76,9 @@ function formatSettings(targets) {
     if (visDirection !== DEFAULT_DIRECTION) {
         settings += "vd=" + visDirection + "&"
     }
+    if (visAlignment !== DEFAULT_ALIGNMENT) {
+        settings += "va=" + visAlignment + "&"
+    }
     if (maxNodeHeight !== DEFAULT_NODE_BREADTH) {
         settings += "nh=" + maxNodeHeight + "&"
     }

--- a/settings.js
+++ b/settings.js
@@ -519,6 +519,19 @@ function renderVisualizerDirection(settings) {
     input.checked = true
 }
 
+let DEFAULT_ALIGNMENT = "right"
+
+let visAlignment = DEFAULT_ALIGNMENT
+
+function renderVisualizerAlignment(settings) {
+    visAlignment = DEFAULT_ALIGNMENT
+    if ("va" in settings) {
+        visAlignment = settings.va
+    }
+    let input = document.getElementById("alignment_" + visAlignment)
+    input.checked = true
+}
+
 const DEFAULT_NODE_BREADTH = 175
 
 let maxNodeHeight = DEFAULT_NODE_BREADTH
@@ -610,6 +623,7 @@ function renderSettings(settings) {
     renderDefaultBeacon(settings)
     renderVisualizerType(settings)
     renderVisualizerDirection(settings)
+    renderVisualizerAlignment(settings)
     renderNodeBreadth(settings)
     renderLinkLength(settings)
     renderValueFormat(settings)

--- a/visualize.js
+++ b/visualize.js
@@ -491,10 +491,18 @@ function renderGraph(totals, ignore) {
         nw = maxNodeWidth
         np = nodePadding
     }
+
+    let alignment
+    if (visAlignment === "right") {
+        alignment = d3sankey.sankeyRight
+    } else if (visAlignment === "left") {
+        alignment = d3sankey.sankeyLeft
+    }
+
     let sankey = d3sankey.sankey()
         .nodeWidth(nw)
         .nodePadding(np)
-        .nodeAlign(d3sankey.sankeyRight)
+        .nodeAlign(alignment)
         .maxNodeHeight(maxNodeHeight)
         .linkLength(linkLength)
     let {nodes, links} = sankey(data)


### PR DESCRIPTION
First off I want to say how much of a fan of your calculator I am! I was introduced to it recently and have been using it a ton ever since.

This commit adds a option in the visualizer settings to adjust the alignment of the Sankey diagram. I find I prefer it to be left aligned a lot more so I figured I would contribute an option for it.

You can play around with my branch live here: https://5f645b0a27caae0008f365a2--kirkmcdonald-factorio-visualizer.netlify.app/calc.html#tab=graph&data=1-0-0&va=left&items=advanced-circuit:f:1

Sorry if this is a bit of a drive by PR with no discussion beforehand.