### PR TITLE
Add item name to document title

### DIFF
--- a/fragment.js
+++ b/fragment.js
@@ -192,3 +192,14 @@ function loadSettings(fragment) {
     }
     return settings
 }
+
+function formatTitle() {
+    var title = "Factorio Calculator"
+
+    var targetName = getTargetItemName(0)
+    if (targetName) {
+        title = targetName + " - " + title
+    }
+
+    return title
+}

--- a/init.js
+++ b/init.js
@@ -222,7 +222,10 @@ function loadData(modName, settings) {
 
         // Prune factory spec after first solution is calculated.
         pruneSpec(globalTotals)
+
+        // Reflect current module to distinguish bookmarks for user info
         window.location.hash = "#" + formatSettings()
+        window.top.document.title = formatTitle()
     })
 }
 

--- a/init.js
+++ b/init.js
@@ -149,7 +149,7 @@ function loadData(modName, settings) {
                 var targetString = targets[i]
                 var parts = targetString.split(":")
                 var name = parts[0]
-                var target = addTarget(name)
+                var target = addTarget(items[name])
                 var type = parts[1]
                 if (type == "f") {
                     var j = parts[2].indexOf(";")

--- a/item.js
+++ b/item.js
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.*/
 "use strict"
 
-function Item(name, col, row, phase, group, subgroup, order) {
+function Item(name, col, row, phase, group, subgroup, order, localized_name) {
     this.name = name
     this.icon_col = col
     this.icon_row = row
@@ -23,6 +23,7 @@ function Item(name, col, row, phase, group, subgroup, order) {
     this.group = group
     this.subgroup = subgroup
     this.order = order
+    this.localized_name = localized_name
 }
 Item.prototype = {
     constructor: Item,
@@ -93,6 +94,7 @@ function getItem(data, items, name) {
             d.group,
             d.subgroup,
             d.order,
+            d.localized_name.en,
         )
         items[name] = item
         return item
@@ -111,6 +113,7 @@ function getItems(data) {
         "production",
         "energy",
         "f[nuclear-energy]-d[reactor-cycle]",
+         reactor.localized_name,
     )
     return items
 }

--- a/target.js
+++ b/target.js
@@ -26,6 +26,20 @@ function addTarget(itemName) {
     return target
 }
 
+function getTargetItemName(i) {
+    if (i > build_targets.length)
+        return null
+
+    var targetName = ""
+
+    var target = build_targets[i]
+    if (target) {
+        targetName = target.itemName
+    }
+
+    return targetName
+}
+
 function isFactoryTarget(recipeName) {
     // Special case: rocket-part and rocket-launch are linked in a weird way.
     if (recipeName === "rocket-part") {

--- a/target.js
+++ b/target.js
@@ -16,10 +16,19 @@ limitations under the License.*/
 var DEFAULT_ITEM = "advanced-circuit"
 
 var build_targets = []
+var build_target_localized_names = {}
 
-function addTarget(itemName) {
+function addTarget(item) {
+    if (!item) {
+        return
+    }
+
+    var itemName = item.name
     var target = new BuildTarget(build_targets.length, itemName)
+
     build_targets.push(target)
+    build_target_localized_names[itemName] = item.localized_name
+
     var targetList = document.getElementById("targets")
     var plus = targetList.replaceChild(target.element, targetList.lastChild)
     targetList.appendChild(plus)
@@ -34,7 +43,10 @@ function getTargetItemName(i) {
 
     var target = build_targets[i]
     if (target) {
-        targetName = target.itemName
+        var localized_name = build_target_localized_names[target.itemName]
+        if (localized_name) {
+            targetName = localized_name
+        }
     }
 
     return targetName


### PR DESCRIPTION
 So that bookmarks and tab can be distinguished from each other.

Otherwise, all browser tabs and all bookmarks have the same Name/Title.