### PR TITLE
Prefix document title with recipe's nice localized (en) name

### DIFF
--- a/display.js
+++ b/display.js
@@ -99,6 +99,11 @@ function pruneSpec(totals) {
         delete spec.ignore[drop[i]]
     }
 }
+function updateDocumentInformation() {
+    // Reflect current module to distinguish bookmarks for user info
+    window.location.hash = "#" + formatSettings()
+    window.top.document.title = formatTitle()
+}
 
 var globalTotals
 
@@ -1264,7 +1269,7 @@ function display() {
     }
     var totals = globalTotals
 
-    window.location.hash = "#" + formatSettings()
+    updateDocumentInformation()
 
     if (currentTab == "graph_tab") {
         renderGraph(totals, spec.ignore)

--- a/events.js
+++ b/events.js
@@ -477,7 +477,7 @@ function clickTab(tabName) {
     var button = document.getElementById(tabMap[tabName])
     button.classList.add("active")
     if (initDone) {
-        window.location.hash = "#" + formatSettings()
+        updateDocumentInformation()
     }
 }
 

--- a/fragment.js
+++ b/fragment.js
@@ -192,3 +192,14 @@ function loadSettings(fragment) {
     }
     return settings
 }
+
+function formatTitle() {
+    var title = "Factorio Calculator"
+
+    var targetName = getTargetItemName(0)
+    if (targetName) {
+        title = targetName + " - " + title
+    }
+
+    return title
+}

--- a/init.js
+++ b/init.js
@@ -133,6 +133,8 @@ function loadData(modName, settings) {
         var items = graph[0]
         var recipes = graph[1]
 
+        buildLocalizedItemNameTable(items)
+
         belts = getBelts(data)
         fuel = getFuel(data, items)["chemical"]
 
@@ -222,7 +224,7 @@ function loadData(modName, settings) {
 
         // Prune factory spec after first solution is calculated.
         pruneSpec(globalTotals)
-        window.location.hash = "#" + formatSettings()
+        updateDocumentInformation()
     })
 }
 

--- a/item.js
+++ b/item.js
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.*/
 "use strict"
 
-function Item(name, col, row, phase, group, subgroup, order) {
+function Item(name, col, row, phase, group, subgroup, order, localized_name) {
     this.name = name
     this.icon_col = col
     this.icon_row = row
@@ -23,6 +23,7 @@ function Item(name, col, row, phase, group, subgroup, order) {
     this.group = group
     this.subgroup = subgroup
     this.order = order
+    this.localized_name = localized_name
 }
 Item.prototype = {
     constructor: Item,
@@ -93,6 +94,7 @@ function getItem(data, items, name) {
             d.group,
             d.subgroup,
             d.order,
+            d.localized_name.en,
         )
         items[name] = item
         return item
@@ -111,6 +113,7 @@ function getItems(data) {
         "production",
         "energy",
         "f[nuclear-energy]-d[reactor-cycle]",
+         reactor.localized_name,
     )
     return items
 }

--- a/target.js
+++ b/target.js
@@ -16,10 +16,55 @@ limitations under the License.*/
 var DEFAULT_ITEM = "advanced-circuit"
 
 var build_targets = []
+var build_target_localized_names = {}
+
+function getLocalizedItemNameCount() {
+    if (build_target_localized_names){
+        return Object.keys(build_target_localized_names).length
+    }
+    else{
+        return 0
+    }
+}
+function buildLocalizedItemNameTable(items) {
+    if (getLocalizedItemNameCount() > 0)
+        return
+
+    if (!items)
+        return
+
+    for (const [itemName, item] of Object.entries(items)) {
+        var localized_name = itemName
+        if (item && item.localized_name) {
+            localized_name = item.localized_name
+        }
+        build_target_localized_names[itemName] = localized_name
+    }
+}
+
+function getTargetItemName(i) {
+    if (i > build_targets.length)
+        return null
+
+    var targetName = ""
+
+    var target = build_targets[i]
+    if (target) {
+        targetName = target.itemName
+        var localized_name = build_target_localized_names[targetName]
+        if (localized_name) {
+            targetName = localized_name
+        }
+    }
+
+    return targetName
+}
 
 function addTarget(itemName) {
     var target = new BuildTarget(build_targets.length, itemName)
+
     build_targets.push(target)
+
     var targetList = document.getElementById("targets")
     var plus = targetList.replaceChild(target.element, targetList.lastChild)
     targetList.appendChild(plus)


### PR DESCRIPTION
This commit enables the document title to reflect the recipe being viewed.

Use Case #1: distinguish between different recipes in a browser's bookmarks.
Use Case #2: distinguish between different browser tabs where different recipes are viewed.

Caveat: Does not attempt to handle multiple items in the recipe.
Reasoning: Handling one item is likely the 80% case.
Further possibilities: It's easy to add an "et al" or similar, or more preferable a user nameable recipe and use that for the 20% case.