### PR TITLE
Support the option of showing other belts after the preferred option.

### DIFF
--- a/calc.css
+++ b/calc.css
@@ -203,6 +203,9 @@ tr.no-mods td.module * {
 td.waste-hide, th.waste-hide {
     display: none;
 }
+td.belt-hide {
+    display: none;
+}
 span.displaylink {
     font-size: x-small;
 }

--- a/calc.html
+++ b/calc.html
@@ -244,6 +244,10 @@ limitations under the License.-->
         <td class="setting-label">Preferred belt:</td>
         <td><span id="belt"></span></td>
         </tr>
+        <tr>
+        <td class="setting-label"><label for="allbelt">Show other belt usages:</label></td>
+        <td><input type="checkbox" id="allbelt" onchange="changeAllBelt(event)" checked></td>
+        </tr>
 
         <tr>
         <td class="setting-label">Minimum pipe length:</td>

--- a/events.js
+++ b/events.js
@@ -201,6 +201,11 @@ function changeBelt(belt) {
     setPreferredBelt(belt.name)
     display()
 }
+// Triggered when the allbelt checkbox is toggled.
+function changeAllBelt(event) {
+    setAllBelt(event.target.checked)
+    display()
+}
 
 // Triggered when the minimum pipe length is changed.
 function changePipeLength(event) {

--- a/fragment.js
+++ b/fragment.js
@@ -53,6 +53,9 @@ function formatSettings(targets) {
     if (preferredBelt != DEFAULT_BELT) {
         settings += "belt=" + preferredBelt + "&"
     }
+    if (allBeltEnabled != DEFAULT_ALLBELT) {
+        settings += "ab=on&"
+    }
     if (!minPipeLength.equal(DEFAULT_PIPE)) {
         settings += "pipe=" + minPipeLength.toDecimal(0) + "&"
     }

--- a/settings.js
+++ b/settings.js
@@ -371,6 +371,8 @@ var DEFAULT_BELT = "transport-belt"
 
 var preferredBelt = DEFAULT_BELT
 var preferredBeltSpeed = null
+var DEFAULT_ALLBELT = false
+var allBeltEnabled
 
 function renderBelt(settings) {
     var pref = DEFAULT_BELT
@@ -403,6 +405,21 @@ function setPreferredBelt(name) {
         }
     }
 }
+
+function renderAllBelt(settings) {
+    var ab = DEFAULT_ALLBELT
+    if ("ab" in settings) {
+        ab = settings.ab === "on"
+    }
+    setAllBelt(ab)
+    var input = document.getElementById("allbelt")
+    input.checked = ab
+}
+
+function setAllBelt(enabled) {
+    allBeltEnabled = enabled
+}
+
 
 // pipe
 var DEFAULT_PIPE = RationalFromFloat(17)
@@ -604,6 +621,7 @@ function renderSettings(settings) {
     renderOil(settings)
     renderKovarex(settings)
     renderBelt(settings)
+    renderAllBelt(settings)
     renderPipe(settings)
     renderMiningProd(settings)
     renderDefaultModule(settings)


### PR DESCRIPTION
Added the option to show the other belts after the preferred option.

As I was constantly switching between two types when trying to layout a design with belt braiding., to check which items needed the fast belt or could be combined onto 1.
I felt that other people might want this functionality, so here it is.

New setting added to enable it, defaulted to off.
Display is updated to show the preferred belt first then the remaining belts in order as in the preferred belt list.
Tested with vanilla (3 belts) and modded (Ultimate Belts, and Bob's Logistics mods) (10 belts) combinations to check displayed layout.