### PR TITLE
Split recipes into categories

### DIFF
--- a/groups.js
+++ b/groups.js
@@ -62,39 +62,48 @@ export function topoSort(groups) {
     return result
 }
 
+export function titleCase(str) {
+    if (str === null || str == undefined) {
+        return "Other"
+    }
+
+    let words = capitalizeFirstLetter(str).split('-')
+    return words.join(' ')
+}
+
+function capitalizeFirstLetter(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
 export function getRecipeGroups(recipes) {
     let groups = new Map()
-    let items = new Set()
     for (let recipe of recipes) {
-        if (recipe.products.length > 0) {
-            groups.set(recipe, new Set([recipe]))
-            for (let ing of recipe.products) {
-                items.add(ing.item)
-            }
+        let category = recipe.category;
+        if (category === null) {
+            category = "other"
         }
-    }
-    for (let item of items) {
-        let itemRecipes = []
-        for (let recipe of item.allRecipes()) {
-            if (recipes.has(recipe)) {
-                itemRecipes.push(recipe)
-            }
+
+        if (!groups.has(category)) {
+            groups.set(category, new Set())
         }
-        if (itemRecipes.length > 1) {
-            let combined = new Set()
-            for (let recipe of itemRecipes) {
-                for (let r of groups.get(recipe)) {
-                    combined.add(r)
-                }
-            }
-            for (let recipe of combined) {
-                groups.set(recipe, combined)
-            }
+        groups.get(category).add(recipe)
+    }
+
+    // Move "recycling" and "other" to the end
+    let sortedGroups = new Map();
+    Array.from(groups.entries()).sort((a, b) => {
+        if (['recycling', "other"].includes(a[0]) && !['recycling', "other"].includes(b[0])) {
+            return 1
         }
-    }
-    let groupObjects = new Set()
-    for (let [r, group] of groups) {
-        groupObjects.add(group)
-    }
-    return groupObjects
+
+        if (!['recycling', "other"].includes(a[0]) && ['recycling', "other"].includes(b[0])) {
+            return -1
+        }
+
+        return 0;
+    }).forEach(([category, recipes]) => {
+        sortedGroups.set(category, new Set(recipes))
+    })
+
+    return Array.from(sortedGroups.values());
 }


### PR DESCRIPTION
Factorio received a lot of new recipes with the release of Space Age dlc. In some cases, there's no point in using alternative recipes, such as the spoiling mechanic (copper bacteria to copper ore, etc.) on space platforms, etc. Also, players may have technology locked behind unexplored planets. For me, I make quite a few changes to the available recipes when planning my factory.

However, it is not very easy. For example, some alternative recipes share the same image, making it difficult to search for something specific. I've been using this awesome project for a long time and here's my contribution: 

I grouped recipes by their category from JSON data. Additionally, each category can be toggled at once (e.g., disabling metallurgy or every organic recipes). 

There is room for improvement, such as custom mapping of recipes to categories, but I didn't want to introduce any manual configuration into the project.

Here is how it looks:

![image](https://github.com/user-attachments/assets/2f180951-ff82-4708-b49e-944564c9c8fd)

<details>
  <summary>GIF</summary>
  
![recording](https://github.com/user-attachments/assets/35726245-da42-46ae-b980-1e3c83edfb98)
</details>



P.S. If the implementation doesn't match your vision, I understand. Just wanted to improve the tool that I use every gaming session