### PR TITLE
Restore ability to use local recipe set

### DIFF
--- a/init.js
+++ b/init.js
@@ -23,7 +23,8 @@ import { getItems } from "./item.js"
 import { getModules } from "./module.js"
 import { getPlanets } from "./planet.js"
 import { getRecipes } from "./recipe.js"
-import { currentMod, MODIFICATIONS, renderDataSetOptions, renderSettings } from "./settings.js"
+import { currentMod, MODIFICATIONS, addOverrideOptions, renderDataSetOptions, renderSettings } from "./settings.js"
+import { OVERRIDE } from "./override.js"
 
 function reset() {
     window.location.hash = ""
@@ -109,6 +110,9 @@ function loadData(modName, settings) {
 
 export function init() {
     let settings = loadSettings(window.location.hash)
+    if (OVERRIDE != null) {
+        addOverrideOptions(OVERRIDE)
+    }
     renderDataSetOptions(settings)
     loadData(currentMod(), settings)
 }

--- a/override.js
+++ b/override.js
@@ -1,0 +1,16 @@
+/*Copyright 2015-2019 Kirk McDonald
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+"use strict"
+
+export let OVERRIDE = null

--- a/settings.js
+++ b/settings.js
@@ -42,6 +42,14 @@ export let MODIFICATIONS = new Map([
 
 let DEFAULT_MODIFICATION = "2-0-10"
 
+export function addOverrideOptions(version) {
+    var tag = "local-" + version.replace(/\./g, "-")
+    MODIFICATIONS.set(tag, new Modification("Local game data " + version, "local-" + version + ".json", false))
+    MODIFICATIONS.set(tag + "x", new Modification("Local game data " + version + " - Expensive", "local-" + version + "-expensive.json", false))
+    DEFAULT_MODIFICATION = tag
+}
+
+
 // Ideally we'd write this as a generalized function, but for now we can hard-
 // code these version upgrades.
 var modUpdates = new Map([


### PR DESCRIPTION
The option to specify a local recipe set using the `OVERRIDE` variable, which [factoriocalc](https://github.com/KirkMcDonald/factorio-tools) depends on, was removed in the rewrite. This pull request adds this feature back to restore factoriocalc functionality.