### PR TITLE
Separate settings for Space Age advanced machines

### DIFF
--- a/building.js
+++ b/building.js
@@ -33,10 +33,10 @@ class Building {
         this.icon = new Icon(this)
     }
     less(other) {
-        if (!this.speed.equal(other.speed)) {
-            return this.speed.less(other.speed)
+        if (this.moduleSlots != other.moduleSlots) {
+            return this.moduleSlots < other.moduleSlots
         }
-        return this.moduleSlots < other.moduleSlots
+        return this.speed.less(other.speed)
     }
     getCount(spec, recipe, rate) {
         return rate.div(this.getRecipeRate(spec, recipe))

--- a/calc.css
+++ b/calc.css
@@ -172,7 +172,7 @@ input.prec, input.mprod {
 .radio-setting input[type="radio"] {
     display: none;
 }
-.radio-setting input[type="radio"] + label {
+.radio-setting input[type="radio"] + label, .toggle-building {
     cursor: pointer;
     background: var(--light);
     border-radius: 4px;
@@ -180,10 +180,10 @@ input.prec, input.mprod {
     margin: 2px;
     padding: 2px;
 }
-.radio-setting input[type="radio"] + label:hover {
+.radio-setting input[type="radio"] + label:hover, .toggle-building:hover {
     background: var(--bright);
 }
-.radio-setting input[type="radio"]:checked + label {
+.radio-setting input[type="radio"]:checked + label, .toggle-building.selected {
     background: var(--accent);
 }
 .toggle-list .toggle {

--- a/calc.html
+++ b/calc.html
@@ -231,6 +231,11 @@ limitations under the License.-->
             <td><span id="building_selector"></span></td>
             </tr>
 
+            <tr id="advanced_building_row" class="setting-row">
+            <td class="setting-label"><div><span>Advanced buildings:</span></div></td>
+            <td><div id="advanced_building_selector"></div></td>
+            </tr>
+
             <tr class="setting-row">
             <td class="setting-label">Mining productivity bonus:</td>
             <td>+<input id="mprod" class="mprod" type="number" step="10" value="0" min="0" onchange="handlers.changeMprod(event)">%</td>

--- a/factory.js
+++ b/factory.js
@@ -489,7 +489,11 @@ class FactorySpecification {
         if (recipe.category === null || recipe.category === undefined) {
             return null
         } else {
-            return this.buildings.get(recipe.category).getBuilding(recipe)
+            let buildingsForCategory = this.buildings.get(recipe.category)
+            if (buildingsForCategory == null) {
+                return null
+            }
+            return buildingsForCategory.getBuilding(recipe)
         }
     }
     getBuildingGroup(building) {

--- a/fragment.js
+++ b/fragment.js
@@ -71,6 +71,12 @@ export function formatSettings(excludeTitle, overrideTab, targets) {
     if (buildings.length > 0) {
         settings += "buildings=" + buildings.join(",") + "&"
     }
+    if (spec.advancedBuildings.size > 0) {
+        let advancedKeys = Array.from(spec.advancedBuildings)
+            .map(b => b.key)
+            .join(",")
+        settings += "advancedbuildings=" + advancedKeys + "&"
+    }
     if (spec.belt.key !== DEFAULT_BELT) {
         settings += "belt=" + spec.belt.key + "&"
     }
@@ -144,7 +150,7 @@ export function formatSettings(excludeTitle, overrideTab, targets) {
         }
         settings += "&planet=" + planets.join(",")
     }
-    let {disable, enable} = spec.getNetDisable()
+    let { disable, enable } = spec.getNetDisable()
     if (disable.size !== 0) {
         let parts = []
         for (let d of disable) {
@@ -198,7 +204,7 @@ export function formatSettings(excludeTitle, overrideTab, targets) {
         let priority = []
         for (let level of spec.priority) {
             let keys = []
-            for (let {recipe, weight} of level) {
+            for (let { recipe, weight } of level) {
                 keys.push(`${recipe.key}=${weight.toString()}`)
             }
             priority.push(keys.join(","))
@@ -233,7 +239,7 @@ export function loadSettings(fragment) {
     if (settings.has("zip")) {
         let z = window.atob(settings.get("zip"))
         let a = z.split("").map(c => c.charCodeAt(0))
-        let unzip = pako.inflateRaw(a, {to: "string"})
+        let unzip = pako.inflateRaw(a, { to: "string" })
         return loadSettings("#" + unzip)
     }
     return settings

--- a/module.js
+++ b/module.js
@@ -198,6 +198,10 @@ export class ModuleSpec {
                 speed = speed.add(beacon)
             }
         }
+        let minimum = Rational.from_floats(1, 5)
+        if (speed.less(minimum)) {
+            speed = minimum
+        }
         return speed
     }
     prodEffect(spec) {

--- a/recipe.js
+++ b/recipe.js
@@ -280,7 +280,7 @@ class SpoilageRecipe extends Recipe {
             to_item.icon_col,
             to_item.icon_row,
             false,
-            null,
+            "spoilage",
             zero,
             [new Ingredient(from_item, one)],
             [new Ingredient(to_item, one)],
@@ -578,7 +578,9 @@ export function getRecipes(data, items) {
             //console.log("item with no recipes or uses:", item)
             reapItems.push(itemKey)
         } else if (item.recipes.length === 0) {
-            console.log("item with no recipes:", item)
+            if (!item.key.endsWith("-barrel")) {
+                console.log("item with no recipes:", item)
+            }
             recipes.set(itemKey, new ResourceRecipe(item, null, 2, hundred))
         }
     }

--- a/settings.js
+++ b/settings.js
@@ -15,7 +15,7 @@ import { DEFAULT_RATE, DEFAULT_RATE_PRECISION, DEFAULT_COUNT_PRECISION, DEFAULT_
 import { colorSchemes } from "./color.js"
 import { DEFAULT_TAB, clickTab, DEFAULT_VISUALIZER, visualizerType, setVisualizerType, DEFAULT_RENDER, visualizerRender, setVisualizerRender, visualizerDirection, getDefaultVisDirection, setVisualizerDirection } from "./events.js"
 import { spec, DEFAULT_PLANET, DEFAULT_BELT, DEFAULT_FUEL, buildingSort } from "./factory.js"
-import { getRecipeGroups } from "./groups.js"
+import { getRecipeCategories, titleCase } from "./groups.js"
 import { changeMod } from "./init.js"
 import { shortModules, moduleRows, moduleDropdown } from "./module.js"
 import { Rational, zero } from "./rational.js"
@@ -67,7 +67,7 @@ function normalizeDataSetName(modName) {
 // initialization, and so does not need to wipe and re-render its UI elements.
 export function renderDataSetOptions(settings) {
     let modSelector = document.getElementById("data_set")
-    d3.select(modSelector).on("change", function(event) {
+    d3.select(modSelector).on("change", function (event) {
         changeMod()
     })
     let configuredMod = normalizeDataSetName(settings.get("data"))
@@ -281,7 +281,7 @@ function renderRateOptions(settings) {
     spec.format.setDisplayRate(rateName)
     let rates = []
     for (let [rateName, longRateName] of longRateNames) {
-        rates.push({rateName, longRateName})
+        rates.push({ rateName, longRateName })
     }
     let form = d3.select("#display_rate")
     form.selectAll("*").remove()
@@ -356,16 +356,16 @@ function renderColorScheme(settings) {
     }
     setColorScheme(color)
     d3.select("#color_scheme")
-        .on("change", function(event, d) {
+        .on("change", function (event, d) {
             setColorScheme(event.target.value)
             spec.display()
         })
         .selectAll("option")
         .data(colorSchemes)
         .join("option")
-            .attr("value", d => d.key)
-            .property("selected", d => d.key === color)
-            .text(d => d.name)
+        .attr("value", d => d.key)
+        .property("selected", d => d.key === color)
+        .text(d => d.name)
 }
 
 function setColorScheme(schemeKey) {
@@ -416,7 +416,7 @@ function renderBuildings(settings) {
     let set = div.selectAll("div")
         .data(groups)
         .join("div")
-            .classed("radio-setting", true)
+        .classed("radio-setting", true)
     radioSetting(
         set,
         d => `building_selector_${groupIndex.get(d)}`,
@@ -743,6 +743,27 @@ function renderRecipes(settings) {
         spec.setDefaultDisable()
     }
 
+    let allGroups = getRecipeCategories(new Set(spec.recipes.values()))
+    let groups = new Map();
+    for (let [category, group] of allGroups) {
+        if (group.size > 1) {
+            groups.set(category, sorted(group, (recipe) => {
+                let item = null
+                if (recipe.products.length > 0) {
+                    item = recipe.products[0].item
+                }
+                if (category == "recycling" && recipe.ingredients.length > 0) {
+                    // Sort recycling recipes by their ingredient, so it follows a familiar order
+                    item = recipe.ingredients[0].item
+                }
+                if (item != null) {
+                    return item.group + "-" + item.subgroup + "-" + item.order
+                }
+                return "zzz-" + recipe.order
+            }))
+        }
+    }
+
     let planetDiv = d3.select("#planet_selector")
         .classed("toggle-list", true)
     planetDiv.selectAll("*").remove()
@@ -751,61 +772,107 @@ function renderRecipes(settings) {
         planetDiv.selectAll("div")
             .data(planets)
             .join("div")
-                .classed("toggle", true)
-                .classed("selected", d => spec.selectedPlanets.has(d))
-                .on("click", function(event, d) {
-                    if (event.shiftKey) {
-                        event.preventDefault()
-                        let selected = spec.selectedPlanets.has(d)
-                        d3.select(this).classed("selected", !selected)
-                        if (selected) {
-                            spec.unselectPlanet(d)
-                        } else {
-                            spec.selectPlanet(d)
-                        }
+            .classed("toggle", true)
+            .classed("selected", d => spec.selectedPlanets.has(d))
+            .on("click", function (event, d) {
+                if (event.shiftKey) {
+                    event.preventDefault()
+                    let selected = spec.selectedPlanets.has(d)
+                    d3.select(this).classed("selected", !selected)
+                    if (selected) {
+                        spec.unselectPlanet(d)
                     } else {
-                        spec.selectOnePlanet(d)
-                        d3.selectAll("#planet_selector .toggle")
-                            .classed("selected", d => spec.selectedPlanets.has(d))
+                        spec.selectPlanet(d)
                     }
-                    d3.selectAll("#recipe_toggles .toggle")
-                        .classed("selected", d => !spec.disable.has(d))
-                    spec.updateSolution()
-                })
-                .append(d => d.icon.make(32))
-    }
+                } else {
+                    spec.selectOnePlanet(d)
+                    d3.selectAll("#planet_selector .toggle")
+                        .classed("selected", d => spec.selectedPlanets.has(d))
+                }
+                d3.selectAll("#recipe_toggles .toggle")
+                    .classed("selected", d => !spec.disable.has(d))
 
-    let allGroups = getRecipeGroups(new Set(spec.recipes.values()))
-    let groups = []
-    for (let group of allGroups) {
-        if (group.size > 1) {
-            groups.push(sorted(group, d => d.order))
-        }
+                d3.selectAll("#recipe_toggles .category-label.toggle ")
+                    .each(function () {
+                        let categoryId = d3.select(this).attr("id")
+                        let isSelected = groups.get(categoryId)
+                            .some(recipe => !spec.disable.has(recipe))
+
+                        d3.select(this).classed("selected", isSelected);
+                    })
+
+                spec.updateSolution()
+            })
+            .append(d => d.icon.make(32))
     }
 
     let div = d3.select("#recipe_toggles")
         .classed("toggle-list", true)
     div.selectAll("*").remove()
-    let recipe = div.selectAll("div")
-        .data(groups)
-        .join("div")
-            .classed("toggle-row", true)
-            .selectAll("div")
-            .data(d => d)
-            .join("div")
-                .classed("toggle recipe", true)
-                .classed("selected", d => !spec.disable.has(d))
-                .on("click", function(event, d) {
-                    let disabled = spec.disable.has(d)
-                    d3.select(this).classed("selected", disabled)
-                    if (disabled) {
-                        spec.setEnable(d)
-                    } else {
-                        spec.setDisable(d)
+
+    for (const [category, recipes] of groups) {
+        let categoryDiv = div.append("div")
+            .attr("class", "toggle-row category")
+
+        categoryDiv.append("div")
+            .text(titleCase(category))
+            .attr("class", "category-label toggle")
+            .attr("id", category)
+            .classed("selected", _ => recipes.some(recipe => !spec.disable.has(recipe)))
+            .on("click", function (event, d) {
+                let disabled = true
+                recipes.forEach(recipe => {
+                    if (!spec.disable.has(recipe)) {
+                        disabled = false
                     }
-                    spec.updateSolution()
                 })
-    recipe.append(d => d.icon.make(32))
+
+                if (disabled) {
+                    recipes.forEach(recipe => {
+                        if (spec.disable.has(recipe)) {
+                            spec.setEnable(recipe)
+                        }
+                    })
+                } else {
+                    recipes.forEach(recipe => {
+                        if (!spec.disable.has(recipe)) {
+                            spec.setDisable(recipe)
+                        }
+                    })
+                }
+
+                d3.selectAll("#recipe_toggles .toggle.recipe")
+                    .classed("selected", d => !spec.disable.has(d))
+
+                d3.select(this).classed("selected", disabled)
+
+                spec.updateSolution()
+            })
+
+        categoryDiv.append("div")
+
+        let recipeGroup = categoryDiv.selectAll("div.recipe")
+            .data(recipes)
+
+        recipeGroup.enter()
+            .append("div")
+            .attr("class", "toggle recipe")
+            .classed("selected", d => !spec.disable.has(d))
+            .on("click", function (event, d) {
+                let disabled = spec.disable.has(d)
+                d3.select(this).classed("selected", disabled)
+                if (disabled) {
+                    spec.setEnable(d)
+                } else {
+                    spec.setDisable(d)
+                }
+
+                spec.updateSolution()
+            })
+            .append("div")
+            .attr("class", "recipe-icon")
+            .append(d => d.icon.make(32))
+    }
 }
 
 // resource priority


### PR DESCRIPTION
Before, they were mixed into a false upgrade chain of the assemblers. Now, they have a separate section where each one can be individually toggled, allowing users to customize the calculator to what buildings they've unlocked so far.

The most notable change here is that when selecting the assembler 3 before, it would also enable many other advanced machines (such as the cryogenics plant), which made it hard to plan correctly around those machines prior to visiting Aquilo.